### PR TITLE
@speednoisemovement: Darken blog text

### DIFF
--- a/sass/custom/_colors.scss
+++ b/sass/custom/_colors.scss
@@ -6,6 +6,7 @@ $artsy_bright: #6a00cc;
 $artsy_noir: #540ba9;
 $artsy_highlight: #873ff0;
 $artsy_bg: #FEFDF3;
+$artsy_text: #636;
 
 //$header-bg: #fff;
 $title-color: $artsy_noir;

--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -48,7 +48,7 @@ $highlight-color: #6A00CC;
 
 body {
   background-color: $artsy_bg;
-  color: $artsy_bright;
+  color: $artsy_text;
   font-family: $serif;
   @media screen and (max-width: 481px) {
     margin: 20px;


### PR DESCRIPTION
https://news.ycombinator.com/item?id=6298542

OLD: 

![screen shot 2013-08-29 at 6 11 38 pm](https://f.cloud.github.com/assets/28120/1053874/4a868606-10f8-11e3-8582-1780cff23421.png)

NEW:

![screen shot 2013-08-29 at 6 11 01 pm](https://f.cloud.github.com/assets/28120/1053876/554c44cc-10f8-11e3-953f-6328c6b7cf70.png)

Note that I went with a very subtle purple rather than a straight black or charcoal. The oft-used `#333` seemed a little jarring against the off-white background:

![screen shot 2013-08-29 at 6 10 42 pm](https://f.cloud.github.com/assets/28120/1053886/795de76c-10f8-11e3-8e82-2858163cb454.png)
