### PR TITLE
@mzikherman: Render a google+ authorship tag when possible

### DIFF
--- a/source/_includes/custom/head.html
+++ b/source/_includes/custom/head.html
@@ -1,3 +1,6 @@
 <!--[if IE 8]>
 <link href="{{ root_url }}/stylesheets/custom/ie_font.css" type="text/css">
 <![endif]-->
+{% if page.google-url %}
+<link rel="author" href="{{ page.google-url }}" />
+{% endif %}

--- a/source/_posts/2012-01-31-beyond-heroku-satellite-delayed-job-workers-on-ec2.markdown
+++ b/source/_posts/2012-01-31-beyond-heroku-satellite-delayed-job-workers-on-ec2.markdown
@@ -8,6 +8,7 @@ author: Joey Aghion
 github-url: http://github.com/joeyAghion
 twitter-url: http://twitter.com/joeyAghion
 blog-url: http://joey.aghion.com
+google-url: https://plus.google.com/+JoeyAghion
 ---
 
 [TL;DR: To supplement Heroku-managed app servers, we launched custom EC2 instances to host Delayed Job worker processes. See the [satellite_setup github repo](https://github.com/joeyAghion/satellite_setup) for rake tasks and Chef recipes that make it easy.]

--- a/source/_posts/2012-07-05-spend-time-with-your-site.markdown
+++ b/source/_posts/2012-07-05-spend-time-with-your-site.markdown
@@ -8,6 +8,7 @@ author: Joey Aghion
 github-url: https://github.com/joeyAghion
 twitter-url: http://twitter.com/joeyAghion
 blog-url: http://joey.aghion.com
+google-url: https://plus.google.com/+JoeyAghion
 ---
 
 Empathy with end users is critical when developing consumer-facing software. Many go [even](http://innonate.com/2011/03/09/hackers-the-canon-of-consumer-facing-products/) [further](http://www.uie.com/articles/self_design/) and argue that you should _be_ your own user to effectively deliver the best experience.

--- a/source/_posts/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2.markdown
+++ b/source/_posts/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2.markdown
@@ -5,8 +5,8 @@ date: 2012-07-10 13:30
 comments: true
 categories: [Jenkins, Testing, Continuous Integration, EC2]
 author: Joey Aghion and Frank Macreery
-
 ---
+
 The [Artsy](http://artsy.net) team faithfully uses [Jenkins](http://jenkins-ci.org) for continuous integration. [As we've described before](http://artsy.github.com/blog/2012/05/27/using-jenkins-for-ruby-and-ruby-on-rails-teams/), our Jenkins master and 8 slaves run on Linode. This arrangement has at least a few drawbacks:
 
 * Our Linode servers are manually configured. They require frequent maintenance, and inconsistencies lead to surprising build failures.

--- a/source/_posts/2013-08-27-introduction-to-aws-opsworks.markdown
+++ b/source/_posts/2013-08-27-introduction-to-aws-opsworks.markdown
@@ -8,6 +8,7 @@ author: Joey Aghion
 github-url: https://www.github.com/joeyAghion
 twitter-url: http://twitter.com/joeyAghion
 blog-url: http://joey.aghion.com
+google-url: https://plus.google.com/+JoeyAghion
 ---
 
 OpsWorks is a new service from Amazon that promises to provide high-level tools to manage your EC2-based deployment. From [the announcement](http://aws.typepad.com/aws/2013/02/aws-opsworks-flexible-application-management-in-the-cloud.html):

--- a/source/_posts/2014-01-30-isolating-spurious-and-nondeterministic-tests.markdown
+++ b/source/_posts/2014-01-30-isolating-spurious-and-nondeterministic-tests.markdown
@@ -8,6 +8,7 @@ author: Joey Aghion
 github-url: https://github.com/joeyAghion
 twitter-url: http://twitter.com/joeyAghion
 blog-url: http://joey.aghion.com
+google-url: https://plus.google.com/+JoeyAghion
 ---
 
 Testing is a critical part of our workflow at [Artsy](https://artsy.net). It gives us confidence to make regular, aggressive enhancements. But anyone who has worked with a large, complex test suite has struggled with occasional failures that are difficult to reproduce or fix.

--- a/source/_posts/2014-04-02-refactoring-infrastructure.markdown
+++ b/source/_posts/2014-04-02-refactoring-infrastructure.markdown
@@ -8,6 +8,7 @@ author: Joey Aghion
 github-url: https://github.com/joeyAghion
 twitter-url: http://twitter.com/joeyAghion
 blog-url: http://joey.aghion.com
+google-url: https://plus.google.com/+JoeyAghion
 ---
 
 [Refactoring](http://martinfowler.com/books/refactoring.html) usually describes chages to _code_. Specifically, small changes that bring a codebase closer to the desired state. By making these changes incrementally and without modifying the end-to-end behavior, we avoid risk and the intermediate broken states that usually plague large-scale changes. But refactoring need not be limited to code. It's also an effective way to make infrastructure improvements.

--- a/source/_posts/2014-05-12-continuous-integration-for-service-oriented-architectures.markdown
+++ b/source/_posts/2014-05-12-continuous-integration-for-service-oriented-architectures.markdown
@@ -8,6 +8,7 @@ author: Joey Aghion
 github-url: https://github.com/joeyAghion
 twitter-url: http://twitter.com/joeyAghion
 blog-url: http://joey.aghion.com
+google-url: https://plus.google.com/+JoeyAghion
 ---
 
 Whatever you have against monolithic architectures, at least they're easy to test. And when those tests succeed, you can be reasonably confident the live app will work the same way.


### PR DESCRIPTION
There's some discussion on the seo@ list about establishing our pages' "authorship" to build "authority." I don't know what those mean but thought our blog should do the same. The instructions are for the author to add the site to the "contributor to" section of their Google+ profile, and for the site to include a link back to the author's Google+ profile. (No one wants to link to their Google+ profiles, so we include a `<link>` tag instead.)

https://support.google.com/webmasters/answer/2539557?hl=en

Search results then look like:
![](http://f.cl.ly/items/1i3F2K1t0q2c2q0o1C2a/Screen%20Shot%202014-06-19%20at%205.11.47%20PM.png)
