### PR TITLE
@orta => Updates celluiloid.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     RedCloth (4.2.9)
     blankslate (2.1.2.4)
-    celluloid (0.16.1)
+    celluloid (0.16.0)
       timers (~> 4.0.0)
     chunky_png (1.3.3)
     classifier-reborn (2.0.3)
@@ -93,3 +93,6 @@ DEPENDENCIES
   pygments.rb
   rake
   rdiscount
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
Version 0.16.1 [has been yanked](https://rubygems.org/gems/celluloid/versions/0.16.1). [No one really knows why](https://github.com/celluloid/celluloid/issues/612). 