### PR TITLE
@orta: Specifies no layout for category feeds.

### DIFF
--- a/_includes/category_feed.xml
+++ b/_includes/category_feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Fixed the layout warnings [with this advice](https://github.com/jekyll/jekyll/issues/2712#issuecomment-51614932).

Tested locally by running

```sh
PRODUCTION="YES" bundle exec jekyll build -d _gh-pages
```

without warnings. 