### PR TITLE
@orta: Automatically deploy site upon push to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,5 @@ env:
 before_install:
 - echo "machine github.com login $GH_TOKEN" > ~/.netrc
 - chmod 600 ~/.netrc
-script:
-- rake build
-after_success:
-- rake deploy:travis
+script: rake build
+after_success: rake deploy:travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 sudo: false
 cache: bundler
+rvm:
+- 2.1.2
 env:
   global:
     secure: U6P/itvYt53J4zwddpwf+kyVMayXpDwSIYho1s6h1hGAQ8H6YGfh0jjEO1wIk6bL2xNTknNGArnFVgPl9cslGx7lz5ouG06CAm8siYpzzw29teOS1FIAN0yldCDPDLcjMg7pdWcJNulPbpQVC/K9V6DShp99o/hrWfHCQ+bAJeg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+sudo: false
+cache: bundler
+env:
+  global:
+    secure: U6P/itvYt53J4zwddpwf+kyVMayXpDwSIYho1s6h1hGAQ8H6YGfh0jjEO1wIk6bL2xNTknNGArnFVgPl9cslGx7lz5ouG06CAm8siYpzzw29teOS1FIAN0yldCDPDLcjMg7pdWcJNulPbpQVC/K9V6DShp99o/hrWfHCQ+bAJeg=
+before_install:
+- echo "machine github.com login $GH_TOKEN" > ~/.netrc
+- chmod 600 ~/.netrc
+script:
+- rake build
+after_success:
+- rake deploy:travis

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 desc 'Builds the site locally'
 task :build do
   puts 'Building site.'
-  puts `PRODUCTION="YES" bundle exec jekyll build -d _gh-pages`
+  sh 'PRODUCTION="YES" bundle exec jekyll build -d _gh-pages'
 end
 
 # Deprecated, but leaving shortcut in because I'm sure Orta, at least, has this

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,12 @@ task :bootstrap do
   puts `bundle install`
 end
 
+desc 'Builds the site locally'
+task :build do
+  puts 'Building site.'
+  puts `PRODUCTION="YES" bundle exec jekyll build -d _gh-pages`
+end
+
 # Deprecated, but leaving shortcut in because I'm sure Orta, at least, has this
 # in his muscle-memory.
 task :init => :bootstrap
@@ -45,8 +51,7 @@ task :deploy do
     puts `git pull origin master`
   end
 
-  puts 'Building site.'
-  puts `PRODUCTION="YES" bundle exec jekyll build -d _gh-pages`
+  Rake::Task['build'].invoke
 
   Dir.chdir('_gh-pages') do
     puts 'Pulling changes from server.'
@@ -61,6 +66,29 @@ task :deploy do
 
     puts 'Pushing to github.'
     puts `git push --quiet > /dev/null 2>&1`
+  end
+end
+
+namespace :deploy do
+
+  desc 'Run on Travis only; deploys the site when built on the master branch'
+  task :travis do
+    branch = ENV['TRAVIS_BRANCH'] # Ensure this command is only run on Travis.
+    pull_request = ENV['TRAVIS_PULL_REQUEST'] #Ensure this command is only not run on pull requests
+
+    abort 'Must be run on Travis' unless branch
+
+    if pull_request != 'false'
+      puts 'Skipping deploy for pull request; can only be deployed from master branch.'
+      exit 0
+    end
+
+    if branch != 'master'
+      puts "Skipping deploy for #{ branch }; can only be deployed from master branch."
+      exit 0
+    end
+
+    Rake::Task['deploy'].invoke
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ end
 
 namespace :deploy do
 
-  desc 'Run on Travis only; deploys the site when built on the master branch'
+  desc 'Run on Travis only; deploys the site when built on the source branch'
   task :travis do
     branch = ENV['TRAVIS_BRANCH'] # Ensure this command is only run on Travis.
     pull_request = ENV['TRAVIS_PULL_REQUEST'] #Ensure this command is only not run on pull requests
@@ -79,12 +79,12 @@ namespace :deploy do
     abort 'Must be run on Travis' unless branch
 
     if pull_request != 'false'
-      puts 'Skipping deploy for pull request; can only be deployed from master branch.'
+      puts 'Skipping deploy for pull request; can only be deployed from source branch.'
       exit 0
     end
 
-    if branch != 'master'
-      puts "Skipping deploy for #{ branch }; can only be deployed from master branch."
+    if branch != 'source'
+      puts "Skipping deploy for #{ branch }; can only be deployed from source branch."
       exit 0
     end
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ url: "http://artsy.net"
 twitter_username: ArtsyOpenSource
 github_username:  Artsy
 
+exclude: [vendor]
 
 markdown: rdiscount
 # markdown: redcarpet


### PR DESCRIPTION
Let me know if I've violated Rakefile etiquette. Additionally, people may still submit PRs from forks, since the `$GH_TOKEN` is only needed to deploy, which PRs don't trigger. 

I should note that this _should_ work on master, but we won't know for sure until we merge. 

Fixes #136.