### PR TITLE
@joey => Fixes to HEAD metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ subtitle: Discover fine engineering.
 google_custom_search: 010245880960712892902:tnjd4ryb3ci
 permalink: /blog/:year/:month/:day/:title/
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://artsy.net"
 twitter_username: ArtsyOpenSource
 github_username:  Artsy
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,8 @@
 
   {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
   <link rel="canonical" href="{{ canonical }}">
+  <link rel="alternate" type="application/rss+xml" title="Artsy Engineering Blog" href="/feed">
+
   <link href="{{ root_url }}/favicon.png" rel="icon">
   <link href="{{ root_url }}/css/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
 


### PR DESCRIPTION
* Our canonical URLs were pointed to artsy.net - https://twitter.com/subdigital/status/641597152431505408
* There was no auto-discovery for RSS - https://twitter.com/subdigital/status/641356648678690817

