### PR TITLE
@anyone: New post: Splitting up a large test suite

### DIFF
--- a/_posts/2012-10-09-how-to-run-rspec-test-suites-in-parallel-with-jenkins-ci-build-flow.markdown
+++ b/_posts/2012-10-09-how-to-run-rspec-test-suites-in-parallel-with-jenkins-ci-build-flow.markdown
@@ -105,3 +105,5 @@ I see a few possible improvements here that might require a bit of work.
 * Build flow could support SCM polling the same way as free-style jobs, avoiding the need for `master-prequel`. We weren't able to get a stable notification of changes from Github with the Jenkins Github plugin.
 
 Please suggest further improvements in the comments below!
+
+(Update: See [Splitting up a large test suite](/blog/2015/09/24/splitting-up-a-large-test-suite/) for a modified approach that splits work approximately evenly among an arbitrary number of sub-jobs.)

--- a/_posts/2015-09-24-splitting-up-a-large-test-suite.markdown
+++ b/_posts/2015-09-24-splitting-up-a-large-test-suite.markdown
@@ -1,0 +1,48 @@
+---
+layout: post
+title: "Splitting up a large test suite"
+date: 2015-09-24 22:13
+comments: true
+author: Joey Aghion
+github-url: https://www.github.com/joeyAghion
+twitter-url: https://twitter.com/joeyAghion
+blog-url: http://joey.aghion.com
+categories: [Ruby, testing, Continuous Integration, Rspec]
+---
+
+A while back, we wrote about [How to Run RSpec Test Suites in Parallel with Jenkins CI Build Flow](/blog/2012/10/09/how-to-run-rspec-test-suites-in-parallel-with-jenkins-ci-build-flow/). A version of that still handles our largest test suite, but over time the initial division of specs became unbalanced. We ended up with some tasks that took twice as long as others. Even worse, in an attempt to rebalance task times, we ended up with awkward file patterns like `'spec/api/**/[a-m]*_spec.rb'`.
+
+To keep our parallel spec tasks approximately equal in size and to support arbitrary concurrency, we've added a new `spec:sliced` task:
+
+<!-- more -->
+
+```ruby
+namespace :spec do
+  task :set_up_spec_files do
+    spec_files = Dir['spec/**/*_spec.rb']
+    @spec_file_digests = Hash[spec_files.map { |f| [f, Zlib.crc32(f)] }]
+  end
+
+  RSpec::Core::RakeTask.new(:sliced, [:index, :concurrency] => :set_up_spec_files) do |t, args|
+    index = args[:index].to_i
+    concurrency = args[:concurrency].to_i
+    t.pattern = @spec_file_digests.select { |f, d| d % concurrency == index }.keys
+  end
+end
+```
+
+As you can see, the `set_up_spec_files` helper task builds a hash of spec file paths and corresponding checksums. When we invoke the `sliced` task with `index` and `concurrency` values (e.g., `0` and `5`), only the spec files with checksums equal to `0` when mod-ed by `5` are run. Thus, the Jenkins build flow would look like:
+
+```java
+parallel (
+  {build("master-ci-task", tasks: "spec:sliced[0,5]")},
+  {build("master-ci-task", tasks: "spec:sliced[1,5]")},
+  {build("master-ci-task", tasks: "spec:sliced[2,5]")},
+  {build("master-ci-task", tasks: "spec:sliced[3,5]")},
+  {build("master-ci-task", tasks: "spec:sliced[4,5]")}
+)
+build("master-ci-succeeded")
+```
+
+Now, spec times _might_ continue to be unbalanced despite files being split up approximately evenly. (For a more thorough approach based on recording spec times, see [knapsack](https://github.com/ArturT/knapsack).) However, this little bit of randomness was a big improvement over our previous approach, and promises to scale in a uniform manner.
+


### PR DESCRIPTION
As requested in https://github.com/artsy/gravity/pull/9251, this adds a post describing the `sliced` approach for splitting up our large rspec test suite for Jenkins' build flow plug-in. I also mentioned it on the old post.

It's a small idea... not sure it's worth a post on its own.