### PR TITLE
@orta: Style fixes

### DIFF
--- a/_posts/2014-11-13-eidolon-retrospective.markdown
+++ b/_posts/2014-11-13-eidolon-retrospective.markdown
@@ -65,7 +65,7 @@ We began main work on the project. Orta and I divided the app into two pieces: a
 
 We used [SBConstants](https://github.com/paulsamuels/SBConstants) to have compile-time safety when referring to storyboard identifiers and we used Swift’s operator overloading to make using these constants [really easy](https://github.com/artsy/eidolon/blob/a96763b7ccee9cd35c30079ff4044779d30e999a/Kiosk/App/UIStoryboardSegueExtensions.swift). For example:
 
-```
+```swift
 override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
     if segue == .LoadAdminWebViewController {
         // code goes here
@@ -124,7 +124,7 @@ It is completely possible to write an open source iOS application, though we did
 
 ReactiveCocoa is *really* great at networking. It forced us to use some good abstractions that we might have otherwise cut corners on. Orta describes complex signal mapping to be “too magic.” For example, you can probably figure out what the following line of code does:
 
-```
+```swift
 RAC(self, "artworks") <~ XAppRequest(.Artworks(auctionID)).filterSuccessfulStatusCodes().mapJSON().catch { (error) -> RACSignal! in
     println("Error: \(error)")
     return RACSignal.empty()

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -449,13 +449,12 @@ article {
 
   @media screen and (max-width: 799px) {
     p.meta-paginate a {
-      float: none;
-      clear: none;
+      float: left;
+      clear: both;
       overflow: hidden;
       text-overflow: ellipsis;
       display: inline-block;
       white-space: nowrap;
-      width: 100%;
     }
   }
 

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -419,9 +419,14 @@ article {
 
   p {
     margin-top: 0px;
+
     & a {
       @include link-underline;
     }
+  }
+
+  ul {
+    margin-bottom: 20px;
   }
 
   p > code {


### PR DESCRIPTION
Particularly, unordered lists and previous/next article links on mobile. 

----------------

Before:

<img width="628" alt="screen shot 2015-09-27 at 10 44 14 am" src="https://cloud.githubusercontent.com/assets/498212/10123366/1f624456-6506-11e5-8d47-d7e936923064.png">

After:

<img width="617" alt="screen shot 2015-09-27 at 10 45 30 am" src="https://cloud.githubusercontent.com/assets/498212/10123368/2702bb00-6506-11e5-94c0-77a392fe9fe5.png">

----------------

Before:

<img width="470" alt="screen shot 2015-09-27 at 10 30 17 am" src="https://cloud.githubusercontent.com/assets/498212/10123377/3338cc98-6506-11e5-9604-c70c094f00ff.png">

After:

<img width="494" alt="screen shot 2015-09-27 at 10 55 51 am" src="https://cloud.githubusercontent.com/assets/498212/10123388/567adaac-6506-11e5-9295-512560767c85.png">

