### PR TITLE
@craigspaeth: Link underlines should be compatible with newlines

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -21,22 +21,10 @@ $text-color: #636;
 
 @mixin link-underline {
   & {
-    display: inline-block;
-    position: relative;
-    text-decoration: none;
+    text-decoration: underline;
     &:active {
-      text-decoration: none;
+      text-decoration: underline;
     }
-  }
-  &::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    display: inline-block;
-    height: 1em;
-    width: 100%;
-    margin-top: 5px;
-    border-bottom: 1px solid #666;
   }
 }
 

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -21,9 +21,13 @@ $text-color: #636;
 
 @mixin link-underline {
   & {
-    text-decoration: underline;
+    background-image: linear-gradient(top, transparent 0, black 1px, transparent 0);
+    background-size: 1px 5px;
+    background-repeat: repeat-x;
+    background-position: bottom;
+    text-decoration: none;
     &:active {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
 }


### PR DESCRIPTION
The `border-bottom` trick to underline links looks bad when links wrap:

<img width="691" alt="screen shot 2015-09-30 at 10 28 42 am" src="https://cloud.githubusercontent.com/assets/28120/10195917/21073a82-675e-11e5-910c-59fe381008dd.png">

Links wrap a lot, especially given the narrow content area. The default behavior looks slightly less bad:

<img width="663" alt="screen shot 2015-09-30 at 10 31 21 am" src="https://cloud.githubusercontent.com/assets/28120/10195978/7090ac46-675e-11e5-887f-ec5c8f0539af.png">

...but still looks bad. I made the easy change, but I'd rather fix the underline thickness. Is that possible?