### PR TITLE
Fix for #172 - Links in the footer are not clickable

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -128,6 +128,7 @@ blockquote {
   width: 100%;
   bottom: 40px;
   position: fixed;
+  z-index: -10; // So logo doesn't cover any active links
   #lrg-mark {
     img {
       margin: 0;


### PR DESCRIPTION
Lowered the z-index of the logo-container so now any links underneath it are clickable.