### PR TITLE
Fix for #94 - Sticky header jump

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -166,6 +166,7 @@ header#banner {
   background-position: 0px 0px;
   background-color: $artsy_bg;
   position: fixed;
+  @include transition(top 0.3s);
 
   &.stuck {
     top: -100px;


### PR DESCRIPTION
Now when the stuck class is added to header#banner, the top property is animated via css.