### PR TITLE
Fix for #184 - Jumping to a section of the overview takes you below t…

### DIFF
--- a/open-source/index.html
+++ b/open-source/index.html
@@ -85,12 +85,10 @@ var sticky = new Waypoint.Sticky({
 
 // scroll to each section smoothly
 $('#page-sidebar a').click( function() {
-  $.scrollTo(
-    $(this).attr("href"),{
-      duration: 800,
-      offset: { 'left':0, 'top': -211 }
-    }
-  );
+  var section = $(this).attr("href");
+  $('html, body').animate({
+    scrollTop: ($(section).offset().top - 210)
+  }, 800);
 });
 
 // set active section when scrolled to


### PR DESCRIPTION
…he top

Clicking on a side nav item now scrolls you to the proper section. This now does not rely on the jquery.scrollTo.min.js plugin, so you might be able to remove this dependency if "scrollTo" is not used anywhere else.