### PR TITLE
Ship the Code Review post for energy

### DIFF
--- a/_posts/2015-11-05-Emergence-Code-Review.markdown
+++ b/_posts/2015-11-05-Emergence-Code-Review.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: 'Emergence: Code Review'
+title: 'Code Review: Emergence'
 date: 2015-11-05T00:00:00.000Z
 comments: false
 categories: [ios, mobile, review, video, code, swift, oss]
 author: orta
 ---
 
-We released the fourth app from the mobile team, [Emergence](https://github.com/artsy/Emergence/), on day one for the new Apple TV and are currently getting around 2k downloads a day. The codebase was created by a single developer, and we didn't want to keep that knowledge siloed. So, I ran an hour long code review session last night where I talked through the codebase, explained why some decisions were made and about the differences between tvOS and UIKit.  
+We released the fourth app from the mobile team, [Emergence](https://github.com/artsy/Emergence/), on day one for the new Apple TV and are currently getting around 2k downloads a day. The codebase was created by a single developer, and we didn't want to keep that knowledge siloed. So, I ran an hour long code review session last night where I talked through the codebase, explained why some decisions were made and about the differences between tvOS and UIKit.
 
 Given that I had been asked to write a blog post about tvOS in general, I felt that making the code review public for anyone to watch would be a nice alternative to the usual long-form writing on this blog.
 

--- a/_posts/2015-12-11-License-and-You.markdown
+++ b/_posts/2015-12-11-License-and-You.markdown
@@ -3,7 +3,7 @@ layout: post
 title: 'Licenses for OSS Code'
 date: 2015-12-10T00:00:00.000Z
 comments: false
-categories: [ios, mobile, review, video, oss]
+categories: [ios, mobile, licensing, video, oss]
 author: orta
 ---
 

--- a/_posts/2016-01-14-eidolon-code-review.markdown
+++ b/_posts/2016-01-14-eidolon-code-review.markdown
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 'Eidolon: Code Review'
+title: 'Code Review: Eidolon'
 date: 2016-01-14T00:00:00.000Z
 comments: false
 categories: [ios, mobile, review, video, code, swift, oss]

--- a/_posts/2016-01-28-being-a-good-open-source-citizen.markdown
+++ b/_posts/2016-01-28-being-a-good-open-source-citizen.markdown
@@ -3,7 +3,7 @@ layout: post
 title: 'Being a Good OSS Citizen'
 date: 2016-01-28T00:00:00.000Z
 comments: false
-categories: [ios, mobile, review, video, code, swift, oss]
+categories: [ios, mobile, code, swift, oss]
 author: ash
 ---
 
@@ -21,15 +21,15 @@ I picked [this one](https://cocoapods.org/pods/MARKRangeSlider) because it did _
 
 But I said it did "almost exactly" what I needed, which meant I'd have to modify it. At this point, many developers either look for a different library or abandon the idea of using an existing library altogether and invent one themselves. That's a shame, because it's almost always faster and easier to improve an existing library than it is to build your own.
 
-So let's step through what I did to modify this library for my needs. First, I checked to see if there was an issue for my feature already opened on the repository; maybe someone else had tried this, and I could benefit from their experience! That wasn't the case, so I forked the library to my personal account and cloned my fork locally. Now I can modify the library's code and commit it to my fork. 
+So let's step through what I did to modify this library for my needs. First, I checked to see if there was an issue for my feature already opened on the repository; maybe someone else had tried this, and I could benefit from their experience! That wasn't the case, so I forked the library to my personal account and cloned my fork locally. Now I can modify the library's code and commit it to my fork.
 
-Next I add the library to my `Podfile`, but I'm clever about it. 
+Next I add the library to my `Podfile`, but I'm clever about it.
 
 ```rb
 pod 'MARKRangeSlider', :path => '../MARKRangeSlider'
 ```
 
-This tells CocoaPods that I'm _working_ on the pod, and, it is stored in a local directory (the one where I cloned my fork). This makes it a "development pod", so that the files in Xcode are actually the ones I've cloned locally. 
+This tells CocoaPods that I'm _working_ on the pod, and, it is stored in a local directory (the one where I cloned my fork). This makes it a "development pod", so that the files in Xcode are actually the ones I've cloned locally.
 
 This is a really important, but subtle point. Normally, CocoaPods downloads copies of the files and stores those copies, but in this case, it refers to the existing files. It doesn't copy them at all: any changes I make to the library while working on my app are to the files I cloned. That means they can be easily committed and pushed up to my fork.
 
@@ -57,6 +57,6 @@ This sounds like a lot, and having written it all out, I guess it is. But it's a
 
 ---
 
-I believe that using existing open source libraries is almost always better than writing your own, and I believe that improvements made to open source ought to be shared. Those beliefs shape my behaviour as a developer, and as a person. 
+I believe that using existing open source libraries is almost always better than writing your own, and I believe that improvements made to open source ought to be shared. Those beliefs shape my behaviour as a developer, and as a person.
 
 Making your first contribution to a project may seem scary, but we all [start somewhere](https://github.com/B-Sides/ELCSlider/pull/1). It gets easier, and in time, you will become a paragon of open source citizenry.

--- a/_posts/2016-02-11-Code-Review-Energy.markdown
+++ b/_posts/2016-02-11-Code-Review-Energy.markdown
@@ -6,7 +6,7 @@ author: orta
 categories: [mobile, ios, review, video, energy, folio, oss]
 ---
 
-We are slowly trying to do high-level code-review views for all of our iOS apps. So far, we've covered [Eidolon](/blog/2016/01/14/eidolon-code-review/) and [Emergence](/blog/2015/11/05/Emergence-Code-Review/). Folio is an app that's been in shipped since early 2012, it's used by our Partners to showcase their works offline, at fairs and on the go. If you want the full spiel, check out [this microsite](http://folio.artsy.net).
+We are slowly trying to do high-level code-review views for all of our iOS apps. So far, we've covered [Eidolon](/blog/2016/01/14/eidolon-code-review/) and [Emergence](/blog/2015/11/05/Emergence-Code-Review/). Folio is an app that's shipped to the App Store in early 2012, it's used by our Partners to showcase their works offline, at fairs and on the go. If you want the full spiel, check out [this microsite](http://folio.artsy.net).
 
 This video talks through a lot of the critical codepaths that go from the App's launch to sending an email, which is the main use-case for the app. We have another video coming up which exclusively covers how Folio does sync between the Artsy API and the app.
 

--- a/_posts/2016-02-11-Code-Review-Energy.markdown
+++ b/_posts/2016-02-11-Code-Review-Energy.markdown
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "Code Review: Energy overview"
+date: 2016-02-11 11:09
+author: orta
+categories: [mobile, ios, review, video, energy, folio, oss]
+---
+
+We are slowly trying to do high-level code-review views for all of our iOS apps. So far, we've covered [Eidolon](/blog/2016/01/14/eidolon-code-review/) and [Emergence](/blog/2015/11/05/Emergence-Code-Review/). Folio is an app that's been in shipped since early 2012, it's used by our Partners to showcase their works offline, at fairs and on the go. If you want the full spiel, check out [this microsite](http://folio.artsy.net).
+
+This video talks through a lot of the critical codepaths that go from the App's launch to sending an email, which is the main use-case for the app. We have another video coming up which exclusively covers how Folio does sync between the Artsy API and the app.
+
+Jump [to YouTube](https://www.youtube.com/watch?v=Xhd25hFzN4o) for the video, or click more for a smaller inline preview.
+
+<!-- more -->
+
+{% youtube Xhd25hFzN4o %}


### PR DESCRIPTION
Adds a blog post for the Energy code review video I made for @mennenia 

@ashfurrow - I changed some of our titles to make it more obvious there's a connection between all the videos, and cleaned up the `review` tag, which is something we could use to link them and more if we choose. Also, my editor removed your extra whitespacing.