### PR TITLE
Fixes iPad layout issue in codeblocks

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -560,13 +560,15 @@ article {
 
 article .article-container-single {
 
-  @media screen and (min-width: 600px) {
-    .entry-content > figure {
+  .entry-content > figure {
+    width: 100%;
+
+    @media screen and (min-width: 800px) {
       margin-left: -56%;
       width: 160%;
       margin-right: 0;
       float: none;
-      max-width:none;
+      max-width: none;
     }
   }
 


### PR DESCRIPTION
So there were two issues: first, we were using a min-width of 600px instead of 800px (that was the only instance we were using 600, figured it was a typo) and also we need to make the clodeblocks full-width on small screens to prevent this:

![screen shot 2016-06-30 at 11 47 05 am](https://cloud.githubusercontent.com/assets/498212/16494714/4f411e18-3eb8-11e6-8c0f-dd1f54d7c66e.png)

Fixes #239.