### PR TITLE
Fix broken "source map" link

### DIFF
--- a/_posts/2016-08-15-vscode.markdown
+++ b/_posts/2016-08-15-vscode.markdown
@@ -79,7 +79,7 @@ Then I can add a breakpoint, and when it is triggered, I have a full stack trace
 
 {% expanded_img /images/vscode/debug.png %}
 
-The breakpoint works through a [source map][, and so the line you expect is the one that you're working in. That stuff is all pretty magic to me. Good on Microsoft, and the node community for pulling that off.
+The breakpoint works through a [source map][source_map], and so the line you expect is the one that you're working in. That stuff is all pretty magic to me. Good on Microsoft, and the node community for pulling that off.
 
 ### Wrapup
 
@@ -115,3 +115,4 @@ VS Code has become my main editor in Ruby and JavaScript, due to having great su
 [po]: https://www.objc.io/issues/19-debugging/lldb-debugging/#printing-objects
 [xcode8]: https://github.com/alcatraz/Alcatraz/issues/475
 [emission_vscode_docs]: https://github.com/artsy/emission/blob/master/docs/vscode.md
+[source_map]: http://blog.teamtreehouse.com/introduction-source-maps


### PR DESCRIPTION
Not sure what you meant to link to, so I picked an article at random.