### PR TITLE
feat(logo): change logo to svg

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,11 @@
 <body>
   <div id="logo-container">
     <div id="lrg-mark">
-      <a href="https://www.artsy.net/"><img src="/images/fixed_logo.png"></a>
+      <a href="https://www.artsy.net/">
+        <svg viewBox="0 0 510 510" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+          <path transform="scale(1, -1) translate(0, -480)" d="M0 -32h512v512h-512v-512v0zM464 16h-80v80h-48v-80h-288v416h416v-416v0zM194 384h-40l-74 -186h38l20 52h72l19 -52h39l-74 186v0zM149 282l25 66l24 -66h-49v0z"/>
+        </svg>
+      </a>
     </div>
   </div>
   <header id="banner">{% include header.html %}</header>

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -130,11 +130,6 @@ blockquote {
   position: fixed;
   z-index: -10; // So logo doesn't cover any active links
   #lrg-mark {
-    img {
-      margin: 0;
-      padding: 0;
-    }
-
     @media screen and (min-width: 800px) {
       display: block;
       height: 40px;


### PR DESCRIPTION
switch out low-res brand logo img for razor sharp svg logo (the svg logo was sourced from the icon font on artsy.net)

before:
<img width="44" alt="screen shot 2016-08-19 at 1 29 51 pm" src="https://cloud.githubusercontent.com/assets/1653832/17818315/0fc2df1c-6611-11e6-99c9-63337ffb7d0e.png">

after: 
<img width="44" alt="screen shot 2016-08-19 at 1 33 08 pm" src="https://cloud.githubusercontent.com/assets/1653832/17818462/ac6abef2-6611-11e6-8314-2e926b789ce8.png">

