### PR TITLE
feat(search): add spinner

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -15,5 +15,9 @@ layout: default
       s.parentNode.insertBefore(gcse, s);
     })();
   </script>
-  <gcse:searchresults-only></gcse:searchresults-only>
+  <gcse:searchresults-only>
+    <div class="spinner-wrapper">
+      <div class="spinner"></div>
+    </div>
+  </gcse:searchresults-only>
 </div>

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -124,6 +124,29 @@ blockquote {
   padding: 0 0 0 20px;
 }
 
+// inspired by: https://github.com/artsy/elan/blob/578334842dbd8673ee727258f88243a490dcf34f/components/lib/mixins.styl#L111
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner-wrapper {
+  text-align: center;
+}
+
+.spinner {
+  $width: 25px;
+  $height: 6px;
+  display: inline-block;
+  background: #6e1fff;
+  width: $width;
+  height: $height;
+  top: calc(50% - #{$height} / 2);
+  left: calc(50% - #{$width} / 2);
+  animation: spin 1s infinite linear;
+}
+
 #logo-container{
   width: 100%;
   bottom: 40px;


### PR DESCRIPTION
addresses: https://github.com/artsy/artsy.github.io/issues/92

add simple spinner (based on style guide) on search page that gets
removed when google loads their results

note: the spinner gets removed slightly before the results render on the
page so the user experience is a little rough