### PR TITLE
Initial WIP on inlining GitHub file references in blog posts

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -76,5 +76,52 @@
 
   <footer>
   </footer>
-
 </div>
+
+<script>
+  $(document).ready(function(){
+    var $blob_links = $('a[href*="github"][href*="blob"]')
+    $blob_links.addClass("magic_github")
+    $blob_links.click(function(e){
+      e.preventDefault(),e.stopPropagation()
+      // Grab a CDN, and XHR-able version
+      // of the github blob url
+      var link = $(this).attr("href").replace("github.com", "cdn.rawgit.com").replace("/blob", "")
+      
+      // Grab the closest parent we should split on
+      var $sibling_split_node = $(this).parents("p, ul")
+      // Get everything after, so we can move it into the new container
+      var $after = $sibling_split_node.nextAll("");
+
+      // Keep track of the top parent for all content
+      var $article = $(this).parents(".content-container")
+
+      var jqxhr = $.ajax(link)
+        .done(function(data) {
+
+          // Generate the presentation section
+          var $figure = $("<figure style='height:500px; overflow-y:scroll;' class='code'></figure>")
+          var $insert = $("<div class='highlight'><pre><code></code></pre></div>")
+
+          // Set up the code's structure
+          $("code", $insert).text(data)
+          $figure.append($insert)
+
+          // These divs bring us back into the existing context
+          var $header = $("<div class ='gh meta-container'><header></header></div>")
+          var $meta = $("<div class ='gh date-container'></div>")
+          var $content = $("<div class ='gh content-container'></div>")
+
+          // Move the after content into the new generated container
+          $content.append($after)
+          
+          // Add the  
+          $article.after([$figure, $header, $meta, $content])
+        })
+
+        .fail(function() {
+          console.warn("Network failed: " + link)
+        })
+    })
+  })
+</script>

--- a/_includes/article.html
+++ b/_includes/article.html
@@ -100,23 +100,27 @@
         .done(function(data) {
 
           // Generate the presentation section
-          var $figure = $("<figure style='height:500px; overflow-y:scroll;' class='code'></figure>")
+          var $figure = $("<figure style='height:500px; overflow-y:scroll;clear: both;' class='code'></figure>")
+          var $title = $("<figcaption><span>FILENAME</figcaption>")
           var $insert = $("<div class='highlight'><pre><code></code></pre></div>")
 
           // Set up the code's structure
           $("code", $insert).text(data)
           $figure.append($insert)
 
+          $injsection = $("<div class ='gh-inline-viewer'></div>")
+          $injsection.append($title, $figure)
+          
           // These divs bring us back into the existing context
-          var $header = $("<div class ='gh meta-container'><header></header></div>")
-          var $meta = $("<div class ='gh date-container'></div>")
-          var $content = $("<div class ='gh content-container'></div>")
+          var $header = $("<div class ='gh meta-container'><header>&nbsp;</header></div>")
+          var $meta = $("<div class ='gh date-container'>&nbsp;</div>")
+          var $content = $("<div class ='gh content-container'><div class='entry-content'></div></div>")
 
           // Move the after content into the new generated container
-          $content.append($after)
+          $(".entry-content", $content).append($after)
           
           // Add the  
-          $article.after([$figure, $header, $meta, $content])
+          $article.after([$injsection, $header, $meta, $content])
         })
 
         .fail(function() {

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -424,17 +424,21 @@ article {
 
   p {
     margin-top: 0px;
-
-    & a {
-      @include link-underline;
-    }
   }
 
   ul {
     margin-bottom: 20px;
-    & a {
+  }
+
+  p  a, ul  a {
       @include link-underline;
-    }
+  }
+
+  p  a.magic_github, ul  a.magic_github {
+    text-decoration-line: underline;
+    text-decoration-style: double;
+    background-image: none;
+    color:orangered;
   }
 
   p > code, li > code  {


### PR DESCRIPTION
Adds support for showing files inline when you link to any _file_ on GitHub - meaning that people clicking those links aren't sent off into another page.
- [ ] Loading State
- [ ] Neat opening animation
- [ ] Handling clicking duplications
- [ ] Highlighting specific LOC
- [ ] text after is re-aligned
- [ ] JS syntax highlight?

![2016-09-11 23_11_50](https://cloud.githubusercontent.com/assets/49038/18423690/250f65cc-7875-11e6-9e6c-322eb683b2d3.gif)
