### PR TITLE
Add support for having a markdown bio above a series

### DIFF
--- a/_includes/_series_bio/open-source-by-default.md
+++ b/_includes/_series_bio/open-source-by-default.md
@@ -1,0 +1,5 @@
+### What is Open Source by Default?
+
+Well, we've been asking ourselves that for a long time.  We have made working in and with Open Source a daily part of life as a developer at Artsy. The ramnifications of this is still something we and the entire industry are trying to understand.
+
+This series focuses a lot on the cultural side of interacting at such a high level with a small team of developers. Offering insight on where we've gone right, and gone wrong. 

--- a/_includes/_series_bio/react-native-at-artsy.md
+++ b/_includes/_series_bio/react-native-at-artsy.md
@@ -1,0 +1,8 @@
+
+<img src="/images/react-native/artsy_react_logo.svg" style="width:200px; float:right;">
+
+### "But the Artsy team is so well known for their Obj-C / Swift work"
+
+We see so much potential in React native as a way to de-silo our mobile engineers, to reduce the amount of code our we write and to speed up the way we build products.
+
+This series covers the reasons why we made that choice, our interactions with React Native, the tooling around it and shows how we've been handling some of the issues that come up as an early adopter.   

--- a/_includes/article.html
+++ b/_includes/article.html
@@ -42,7 +42,7 @@
         Categories: {% include post/categories.html %}
       </p>
       {% if page.series %}
-       <p class="meta-series" style="padding-bottom:0;">Part of a series: <strong>{{page.series}}</strong></p>
+       <p class="meta-series" style="padding-bottom:0;">Part of a series: <strong>{{ page.series | series_link }}</strong></p>
        <ul>
          {% for post in site.posts %}
           {% if post.series == page.series %}

--- a/_layouts/series_index.html
+++ b/_layouts/series_index.html
@@ -19,7 +19,9 @@ footer: false
   {% endfor %}
 </div>
 
-<div class="index-main">
+<div class="index-main" style="padding-top:0px">
+{{ page.series | series_bio }}
+
 {% for post in page.posts %}
   <article>
     {% include archive_post.html %}

--- a/_plugins/series_index.rb
+++ b/_plugins/series_index.rb
@@ -88,33 +88,26 @@ module Jekyll
   # Adds some extra filters used during the series creation process.
   module Filters
 
-    # # Outputs a list of seriess as comma-separated <a> links. This is used
-    # # to output the series list for each post on a series page.
-    # #
-    # #  +series+ is the list of series to format.
-    # #
-    # # Returns string
-    # #
+    # Outputs a list of seriess as comma-separated <a> links. This is used
+    # to output the series list for each post on a series page.
+    #
+    #  +series+ is the list of series to format.
+    #
+    # Returns string
+    #
     def series_link(series)
-          require 'pry'
-          binding.pry
-
-      dir = @context.registers[:site].config['series_dir']
-      "<a class='series' href='/#{dir}/#{series.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase}/'>#{item}</a>"
+      dir = "series"
+      series_id = series.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase
+      "<a class='series' href='/#{dir}/#{series_id}/'>#{series}</a>"
     end
 
-    # # Outputs the post.date as formatted html, with hooks for CSS styling.
-    # #
-    # #  +date+ is the date object to format as HTML.
-    # #
-    # # Returns string
-    # def date_to_html_string(date)
-    #   result = '<span class="month">' + date.strftime('%b').upcase + '</span> '
-    #   result += date.strftime('<span class="day">%d</span> ')
-    #   result += date.strftime('<span class="year">%Y</span> ')
-    #   result
-    # end
-
+    # Gets a series name, and pulls out a markdown header file
+    # returning either the rendered markdown, or nothing
+    def series_bio(series)
+      series_id = series.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase
+      bio_path = "_includes/_series_bio/#{series_id}.md"
+      return "" unless File.exist?(bio_path)
+      markdownify(File.read(bio_path))
+    end
   end
-
 end


### PR DESCRIPTION
Had a train ride, choo choo. 

Posts now will link to their series, and a series index can now contain a header bio in markdown

e.g.
![screen shot 2016-09-26 at 18 17 09](https://cloud.githubusercontent.com/assets/49038/18845177/7db0ed50-8418-11e6-8244-f3f88a17885c.png)
