### PR TITLE
add an offset to anchor links

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -118,6 +118,14 @@ a, a:hover, a:visited, a:active {
   color: $artsy_text;
 }
 
+a[name]:before {
+  display: block;
+  content: '';
+  margin-top: -121px;
+  height: 121px;
+  visibility: hidden;
+}
+
 img {
   max-width: 100%;
   margin: 20px 0;


### PR DESCRIPTION
When you're linking to a specific hash, it'd be useful that the link would transport you to the exact location of that location.

Because there's static header of `221px`, the offset here is `121px`. I'm not exactly sure how to calculate that, but some trial and error put me on this exact value. Note that when the header isn't collapsed this won't be right, but then you'd be linked to the top of the page, since it would be visible already.


for example in [Emission](https://github.com/artsy/emission) you link to the [JS Glossary]http://artsy.github.io/blog/2016/11/14/JS-Glossary() like `http://artsy.github.io/blog/2016/11/14/JS-Glossary/#yarn`.