### PR TITLE
Reduce longform article width

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -424,8 +424,8 @@ header#banner {
 
   .article-container-single {
     margin: 5% auto;
-    max-width: 1200px;
-    width: 90%;
+    max-width: 700px;
+    width: 100%;
 
     .content-container {
       width: auto;
@@ -1168,7 +1168,7 @@ figure.code {
       display: inline-block;
       padding-right:4px;
     }
-    
+
     .author {
       border-left: 1px solid black;
       padding-left: 10px;


### PR DESCRIPTION
This is certainly open for debate, but when clicking through to the [longform article](http://artsy.github.io/blog/2017/02/05/Front-end-JavaScript-at-Artsy-2017/) off of Jest's website today it immediately struck me that the reading width is far wider than what the eyes are naturally comfortable with. 

Going over to Medium (where I assume they've done an enormous amount of user testing) I see that they've capped their width at 700px, and so I've brought this PR in line with that. 

This also reduces some of the cramp between the Artsy logo and the left-hand content margin.

**Before:** 

![screen shot 2017-02-21 at 11 55 38 am](https://cloud.githubusercontent.com/assets/236943/23182282/d90865ba-f82c-11e6-8e75-bf640cb66f7d.png)

**After:**

<img width="1382" alt="screen shot 2017-02-21 at 11 56 06 am" src="https://cloud.githubusercontent.com/assets/236943/23182284/df69372c-f82c-11e6-9524-9f580317c43b.png">

Thoughts?  