### PR TITLE
Bugfix - Missing CSS media query style for blog archives list

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -330,9 +330,10 @@ header#banner {
       }
     }
   }
-  #search-container {
+  #search-container, #blog-archives {
     margin-left: 0 !important;
   }
+  
 }
 
 #main {


### PR DESCRIPTION
Couldn't find an specific issue for that but there was a element selector missing for small screens media query that made it very hard to navigate through the archived (and authors) posts list when using a mobile browser.

| Before | After |
|---|---|
| <img width="487" alt="screenshot 2017-08-27 11 18 02" src="https://user-images.githubusercontent.com/700480/29750642-ea0f060e-8b19-11e7-82f1-8ee2c9164eb2.png"> | <img width="487" alt="screenshot 2017-08-27 11 18 19" src="https://user-images.githubusercontent.com/700480/29750644-eec25a84-8b19-11e7-8807-67b5e5865ba7.png"> |

I still have some concerns on how `#id`s are being used on CSS and some elements like the post list in different pages today have duplicated styles, but that would require a larger change and styles refactoring than I can afford to do now 😥 
