### PR TITLE
@orta => Adjust mobile layout padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The Artsy OSS page and the blog runs on top of a default jekyll install. If you 
 ```
   git clone git@github.com:artsy/artsy.github.io.git
   cd artsy.github.io
-  rake bootstrap
-  rake build
+  bundle exec rake bootstrap
+  bundle exec rake build
 ```
 
 ## Running the OSS Site / Blog locally
@@ -16,14 +16,14 @@ The Artsy OSS page and the blog runs on top of a default jekyll install. If you 
 Running `rake serve` will _not_ generate category pages. They take a _long_ time to generate. No one wants that when working on the site.
 
 ```
-  rake serve
+  bundle exec rake serve
 ```
 
 Categories are generated when the ENV var `PRODUCTION` = `"YES"`.
 
 ## Deploying
 
-Travis CI will automatically deploy when new commits are pushed to the `source` branch, so you should not need to deploy from your local computer. However, if you need to deploy locally, the `rake deploy` command is available. 
+Travis CI will automatically deploy when new commits are pushed to the `source` branch, so you should not need to deploy from your local computer. However, if you need to deploy locally, the `rake deploy` command is available.
 
 ## Adding an Author
 

--- a/_sass/epic.scss
+++ b/_sass/epic.scss
@@ -9,7 +9,7 @@ body > div > div {
 }
 
 body > div > div > header {
-  display: flex; 
+  display: flex;
   justify-content: space-between;
   padding-top: 48px;
 
@@ -41,7 +41,12 @@ article.post {
   margin: 0 auto;
   padding-left: 20px;
   padding-right: 20px;
-  
+
+  @media screen and (max-width: 480px) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   figure.code {
     float: none;
   }
@@ -90,7 +95,7 @@ article.post {
   }
 
 
-  & > table, & > blockquote > table { 
+  & > table, & > blockquote > table {
     margin: 0 auto;
     padding: 30px 0;
   }
@@ -102,7 +107,7 @@ body > div > div .comment {
   background-repeat: no-repeat;
   background-position: 60px 10px;
   margin-bottom: 20px;
-  
+
   .comment-header {
     color: #999;
   }
@@ -122,7 +127,7 @@ body > div > div .comment {
     padding-left: 90px;
     padding-top: 10px
   }
-  
+
   img {
     border-radius: 3px !important;
     vertical-align: middle;
@@ -139,7 +144,7 @@ body > div > div > footer {
   padding-top: 30px;
 
   article {
-    display: flex; 
+    display: flex;
 
     section {
       flex: 1;
@@ -164,8 +169,26 @@ body > div > div > footer {
 
 
 .split-desktop-only {
-  display: flex; 
+  display: flex;
   flex-flow:row;
+}
+
+@media screen and (max-width: 480px) {
+  body {
+    padding: 20px;
+  }
+
+  body > div > div > header {
+    padding-top: 0;
+
+    li {
+      font-size: 18px;
+    }
+  }
+
+  body > div > div > section > header#page h1 {
+    font-size: 45px;
+  }
 }
 
 @media screen and (max-width: 800px) {
@@ -173,7 +196,7 @@ body > div > div > footer {
     margin-top: 60px;
     margin-bottom: 60px;
   }
-  
+
   body > div > div > footer article {
     flex-direction: column;
     section {


### PR DESCRIPTION
**Before:** 

<img width="206" alt="screen shot 2017-09-17 at 5 01 53 pm" src="https://user-images.githubusercontent.com/236943/30526126-3a246c54-9bca-11e7-8874-580a924b5c53.png">

**After:**

<img width="226" alt="screen shot 2017-09-17 at 5 02 02 pm" src="https://user-images.githubusercontent.com/236943/30526127-4586711e-9bca-11e7-87b8-ff38ad8337c2.png">

Thinking... Looking around the blog code things are definitely showing their age. Would love to try an experimental migration over to [Gatsby](https://www.gatsbyjs.org/) at some point just to see what kind of effort it would take given existing content. 
