### PR TITLE
Fix broken link to comments

### DIFF
--- a/_posts/2017-07-06-React-Native-for-iOS-devs.markdown
+++ b/_posts/2017-07-06-React-Native-for-iOS-devs.markdown
@@ -317,7 +317,7 @@ react-native init TrendingArtists
 
 <p>Next up we're going to make the initial project and look around, so once all the installing has finished. You can follow along with the next section.</p>
 
-<p>If the command `react-native` isn't working, <a href='https://github.com/keitaito'>@keitaito</a> has some useful advice in the [comments](#comments).</p>
+<p>If the command `react-native` isn't working, <a href='https://github.com/keitaito'>@keitaito</a> has some useful advice in the <a href='#comments'>comments</a>.</p>
 
 </div>
 </article>


### PR DESCRIPTION
For some reason Markdown wasn't picking this up as a link, I'm hoping using an explicit anchor tag will.

<img width="531" alt="screen shot 2017-10-01 at 7 30 25 pm" src="https://user-images.githubusercontent.com/1180883/31057722-680443ea-a6df-11e7-8971-783fd5389ca2.png">
