### PR TITLE
use ruby api to retrieve spec details

### DIFF
--- a/_posts/2018-03-19-making-a-components-pod.markdown
+++ b/_posts/2018-03-19-making-a-components-pod.markdown
@@ -275,8 +275,8 @@ Pod::Spec.new do |s|
     'node_modules/react-native/third-party-podspecs/glog.podspec'
   ]
   podspecs.each do |podspec_path|
-    podspec_json = JSON.parse(`pod ipc spec #{podspec_path}`)
-    s.dependency podspec_json['name'], podspec_json['version']
+    spec = Pod::Specification.from_file podspec_path
+    s.dependency spec.name, "#{spec.version}"
   end
 end
 ```


### PR DESCRIPTION
same as what has been done for Emission. 

Same disclaimer; it could be that `root` has to be prepended, which was the case in my implementation.