### PR TITLE
Fixes author pages with multiple-author posts

### DIFF
--- a/_layouts/author_index.html
+++ b/_layouts/author_index.html
@@ -26,8 +26,7 @@ footer: false
   </h1>
 
 {% for post in site.posts %}
-
-  {% if post.author == site.current_author %}
+  {% if post.author == site.current_author or post.author contains site.current_author %}
   {% capture this_year %}{{ post.date | date: "%Y" }}{% endcapture %}
   {% unless year == this_year %}
     {% assign year = this_year %}


### PR DESCRIPTION
I noticed [my author page](http://artsy.github.io/author/ash/) wasn't including any posts where the `author` frontmatter was an array. This should fix it.