### PR TITLE
Make quitting the server less noisy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,16 +18,25 @@ end
 task :init => :bootstrap
 
 namespace :serve do
+  def run_server(extra_flags = "")
+    jekyll = Process.spawn('PRODUCTION="NO" bundle exec jekyll serve --watch --port 4000 ' + extra_flags)
+    trap("INT") {
+      Process.kill(9, jekyll) rescue Errno::ESRCH
+      exit 0
+    }
+    Process.wait(jekyll)
+  end
+
   desc 'Runs a local server *with* draft posts and watches for changes'
   task :drafts do
     puts 'Starting the server locally on http://localhost:4000'
-    sh 'PRODUCTION="NO" jekyll serve --watch --drafts --port 4000'
+    run_server '--drafts'
   end
 
   desc 'Runs a local server *without* draft posts and watches for changes'
   task :published do
     puts 'Starting the server locally on http://localhost:4000'
-    sh 'PRODUCTION="NO" jekyll serve --watch --port 4000'
+    run_server
   end
 end
 


### PR DESCRIPTION
Our `Rakefile` stars the Jekyll server using `sh`, but when we hit ctrl-c to stop the server, `rake` interprets that interrupt as an error and produces a big stack trace:

![screen shot 2018-10-05 at 3 44 49 pm](https://user-images.githubusercontent.com/498212/46556811-cdab6e00-c8b5-11e8-9370-0640299b4bbc.png)

This PR puts the Jekyll server in its own process and traps the ctrl-c interrupt to `kill -9` that process:

![screen shot 2018-10-05 at 3 43 41 pm](https://user-images.githubusercontent.com/498212/46556842-e451c500-c8b5-11e8-9099-758963622929.png)
