### PR TITLE
Fix url to mjml.io

### DIFF
--- a/_posts/2018-11-19-mjml.markdown
+++ b/_posts/2018-11-19-mjml.markdown
@@ -44,7 +44,7 @@ clients that were built this year isn't easily done. That's where MJML comes in.
 
 ## What is MJML?
 
-[MJML](mjml.io), short for Mailjet Markup Language, is a markup language that is written like simplified HTML/CSS
+[MJML](https://mjml.io), short for Mailjet Markup Language, is a markup language that is written like simplified HTML/CSS
 and renders email-friendly, responsive HTML. So instead of having to code a few thousand lines of complex HTML, you
 code a couple hundred lines of MJML, and it outputs code that looks good on _every single client_.
 


### PR DESCRIPTION
It currently links to `http://artsy.github.io/blog/2018/11/19/mjml/mjml.io` when generated