### PR TITLE
Change underscores in author keys to hyphens, so that author links work

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -240,11 +240,11 @@ authors:
     github: ds300
     twitter: djsheldrick
 
-  matt_dole:
+  matt-dole:
     name: Matt Dole
     github: mdole
 
-  steve_hicks:
+  steve-hicks:
     name: Steve Hicks
     github: pepopowitz
     twitter: pepopowitz

--- a/_posts/2018-11-19-mjml.markdown
+++ b/_posts/2018-11-19-mjml.markdown
@@ -3,7 +3,7 @@ layout: epic
 title: How hard could it be to create an email?
 date: 2018-11-19
 categories: [email, mjml, html, rails]
-author: [erik, matt_dole]
+author: [erik, matt-dole]
 ---
 
 <!-- OUTLINE -->
@@ -44,9 +44,9 @@ clients that were built this year isn't easily done. That's where MJML comes in.
 
 ## What is MJML?
 
-[MJML](https://mjml.io), short for Mailjet Markup Language, is a markup language that is written like simplified HTML/CSS
-and renders email-friendly, responsive HTML. So instead of having to code a few thousand lines of complex HTML, you
-code a couple hundred lines of MJML, and it outputs code that looks good on _every single client_.
+[MJML](https://mjml.io), short for Mailjet Markup Language, is a markup language that is written like simplified
+HTML/CSS and renders email-friendly, responsive HTML. So instead of having to code a few thousand lines of complex
+HTML, you code a couple hundred lines of MJML, and it outputs code that looks good on _every single client_.
 
 ```html
 <mjml>
@@ -63,10 +63,10 @@ code a couple hundred lines of MJML, and it outputs code that looks good on _eve
     </mj-attributes>
   </mj-head>
   <mj-body width="450px" background-color="#fff">
-    <mj-section padding="20px" border="1px solid #e5e5e5"  border-bottom="0">
+    <mj-section padding="20px" border="1px solid #e5e5e5" border-bottom="0">
       <mj-group>
         <mj-column vertical-align="middle" width="19%">
-          <mj-image width="66px" align="left" padding="0" src="jared-french-prose.png"/>
+          <mj-image width="66px" align="left" padding="0" src="jared-french-prose.png" />
         </mj-column>
         <mj-column padding-left="20px" vertical-align="middle" width="81%">
           <mj-text>Order #B135790</mj-text>

--- a/_posts/2019-01-23-artsy-engineering-hiring.md
+++ b/_posts/2019-01-23-artsy-engineering-hiring.md
@@ -2,7 +2,7 @@
 layout: epic
 title: "How Artsy Hires Engineers"
 date: "2019-01-23"
-author: [ash, lily, steve_hicks]
+author: [ash, lily, steve-hicks]
 categories: [people, best practices, hiring, culture, process, team]
 css: artsy-engineering-hiring
 comment_id: 528


### PR DESCRIPTION
Currently, clicking on my name or @mdole's name next to an article takes you to a nonexistent page. 

This is because we put `_` in our author keys. When the author pages are generated, [`_` are replaced with `-`](https://github.com/artsy/artsy.github.io/blob/2a3217947df034c3f29db153441a49b5c3c18997/_plugins/author_generator.rb#L59) - but all the links to the author pages take the key verbatim. 

## The simplest fix

This PR includes the simplest way to fix this - replacing any author keys that use underscores to use hyphens instead. Right now that's me & @mdole.

## A better way that I can't figure out

This could be more permanently fixed by changing all the references to `author/{{key}}` to also replace `_` with `-`. [It appears there is even a filter to do this already](https://github.com/artsy/artsy.github.io/blob/2a3217947df034c3f29db153441a49b5c3c18997/_plugins/author_generator.rb#L95). Unfortunately, I tried updating all the `author/{{key}}` instances to `author/{{key | author_link}}`, and I got errors building: 

```
            Source: /Users/stevenhicks/_sjh/dev/artsy/artsy.github.io
       Destination: _gh-pages
      Generating...
              Lunr: Creating search index...
              Lunr: Index ready (lunr.js v1.0.0)
  Liquid Exception: undefined local variable or method `item' for #<Liquid::Strainer:0x00007f80e3182a48> in _includes/archive_post.html, included in blog/categories/team/index.html
jekyll 2.5.3 | Error:  undefined local variable or method `item' for #<Liquid::Strainer:0x00007f80e3182a48>
rake aborted!
```

This is very possibly (probably) just a case of me not knowing what I'm doing in Jekyll/Liquid templates. 

## Conclusion

If you see what I might be doing wrong here, I'm happy to update the PR. Otherwise, I think this simple fix solves the problem. When people in the future add multi-name author keys, they'll hopefully see ours as examples, and follow the pattern.