### PR TITLE
Adds date to blog posts under the title

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -15,6 +15,7 @@
         {% else %}
           <h2 class="entry-title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h2>
         {% endif %}
+        <time datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date: "%b %-d, %Y" }}</time>
           <p class="meta-author">{% include post/mini-author.html %}</p>
           </a>
       </header>

--- a/_layouts/epic.html
+++ b/_layouts/epic.html
@@ -30,6 +30,7 @@
           <!-- Yep, single line so the comma lines up right -->
           By {% for key in page.author %}{% assign author = site.authors[key] %}{% if forloop.index > 1 %},{% endif %} {{ author.name }}{% endfor %}
           </h3>
+          <time datetime="{{page.date | date: "%Y-%m-%d"}}">{{ page.date | date: "%b %-d, %Y" }}</time>
         </header>
 
         <article class='post'>
@@ -65,7 +66,7 @@
 
           <section>
             <h4>Post Meta</h4>
-            <p>{{ page.date | date: "%b %d, %Y"  }}</p>
+            <p>{{ page.date | date: "%b %-d, %Y"  }}</p>
             <p>Tagged: {{ page.categories | category_links }}</p>
           </section>
           <br/>

--- a/_sass/epic.scss
+++ b/_sass/epic.scss
@@ -32,6 +32,12 @@ body > div > div > section > header#page {
     font-size: 22px;
     font-weight: 400;
   }
+  time {
+    font-size: 22px;
+    font-weight: 400;
+    padding-top: 5px;
+    color: #999;
+  }
 }
 
 article.post {

--- a/_sass/epic.scss
+++ b/_sass/epic.scss
@@ -36,7 +36,6 @@ body > div > div > section > header#page {
     font-size: 22px;
     font-weight: 400;
     padding-top: 5px;
-    color: #999;
   }
 }
 


### PR DESCRIPTION
Beyond being a good general guideline, on blog posts that deal with fast-changing technologies (like ours), it's _especially_ important to include the date of the post near the title of the post. This was [brought up on Slack](https://artsy.slack.com/archives/C02BGC5PW/p1557947974081900?thread_ts=1557947912.081800&cid=C02BGC5PW) and I wanted to tackle this now.

Here's what this looks like on classic posts:

<img width="931" alt="Screen Shot 2019-05-15 at 4 31 07 PM" src="https://user-images.githubusercontent.com/498212/57807618-86c90500-772f-11e9-9921-d95de57d6f78.png">

And here's what it looks like on the modern, "epic" layout:

<img width="923" alt="Screen Shot 2019-05-15 at 4 31 03 PM" src="https://user-images.githubusercontent.com/498212/57807640-934d5d80-772f-11e9-996d-ec10490f9d9b.png">

(I went with the same grey here that we use for datestamps on comments.)

I'm open to design feedback on this 👍 

Fixes #544.