### PR TITLE
Updates Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.5.1
+- 2.6.3
 branches:
   except:
     - master


### PR DESCRIPTION
This is to workaround a bug on CI, detailed in this blog post: https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html Here's an example of the failing build: https://travis-ci.org/artsy/artsy.github.io/builds/583730734

Since deploys are done from Travis, we'll be blocked on new posts until we get this fixed.