### PR TITLE
Fixes Danger invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ install:
 
 script:
   - rake build
-  - '[ ! -z $DANGER_GITHUB_API_TOKEN ] && bundle exec danger || echo "Skipping Danger for External Contributor"'
+  - '[ -z $DANGER_GITHUB_API_TOKEN ] && echo "Skipping Danger for External Contributor" || bundle exec danger'
 
 after_success: rake deploy:travis


### PR DESCRIPTION
@pepopowitz noticed that in #622 I missed the `<!-- more -->` teaser tag. We have a Danger rule for this specific problem, but Danger failed to catch the problem in the PR. It failed because the `DANGER_GITHUB_API_TOKEN` environment variable was no longer valid, so the invocation failed. Normally, Danger would fail the build, but it didn't because of how we structured the CI config. Let me explain.

We skip the Danger requirement for pull requests from external contributors because they don't have access to the environment variable on their builds. But how our script innovation worked had us ignoring the Danger failure. Reversing the order should fix this.

I have also updated the Travis config with a valid GitHub personal access token.