### PR TITLE
Correct open-source category rendering order

### DIFF
--- a/open-source/index.html
+++ b/open-source/index.html
@@ -21,7 +21,7 @@ exclude_from_search: true
   <div id="lead">
     <h1>We love open source at Artsy. We use a ton of it. We've also contributed to numerous projects and created many of our own projects since early 2011. We maintain a philosophy of keeping our work <a href="http://code.dblock.org/2015/02/09/becoming-open-source-by-default.html">Open by Default</a>.</h1>
   </div>
-  {% assign categories = "featured, javascript, ios, devops, ruby" | split: ", " %}
+  {% assign categories = "featured, javascript, ios, ruby, devops" | split: ", " %}
   {% for category in categories %}
     <section id="{{category}}" class="open-source-category">
       <div class="open-source-category-header"><div class="open-source-category-header-title"><span><b>Title</b></span></div><div class="open-source-category-header-description"><span><b>Description</b></span></div><div class="open-source-category-header-updated"><span><b>Created</b></span></div><footer></footer></div>


### PR DESCRIPTION
Switching iteration order of `ruby` and` devops` categories so they render in order of navigation links.

Sorry my mental model not matching the scrollto functionality was killing me :)