### PR TITLE
Set href in link for RSS auto discovery.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 twitter_username: ArtsyOpenSource
 github_username: Artsy
 
+subscribe_rss: /feed.xml
+
 disqus_short_name: artsy
 disqus_show_comment_count: false
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,7 +42,7 @@
   <script type="text/javascript" src="https://fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js"></script>
 
 
-  <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
+  <link href="{{ root_url }}/{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
   {% include google_analytics.html %}
   <!--[if IE 8]><link href="{{ root_url }}/stylesheets/custom/ie_font.css" type="text/css"><![endif]-->
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,7 +42,7 @@
   <script type="text/javascript" src="https://fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js"></script>
 
 
-  <link href="{{ root_url }}/{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
+  <link href="{{ root_url }}{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
   {% include google_analytics.html %}
   <!--[if IE 8]><link href="{{ root_url }}/stylesheets/custom/ie_font.css" type="text/css"><![endif]-->
 


### PR DESCRIPTION
⚠️ I had trouble installing dependencies so I wasn't able to _actually_ test these changes locally 😬 

## Issue
The `href` inside the head for is empty because `subscribe_rss` isn't defined but being used in `_includes/head.html`

```html
<link href="" rel="alternate" title="Artsy Engineering" type="application/atom+xml">
```

## Solution
Define `subscribe_rss` and and update `_includes/head.html` to use `root_url`