### PR TITLE
chore: update dependencies to fix macos bundler problems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     blankslate (2.1.2.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    chunky_png (1.3.3)
+    chunky_png (1.3.15)
     claide (1.0.1)
     claide-plugins (0.9.2)
       cork
@@ -33,14 +33,14 @@ GEM
     colorator (0.1)
     colored (1.2)
     colored2 (3.1.2)
-    compass (1.0.1)
+    compass (1.0.3)
       chunky_png (~> 1.2)
-      compass-core (~> 1.0.1)
+      compass-core (~> 1.0.2)
       compass-import-once (~> 1.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       sass (>= 3.3.13, < 3.5)
-    compass-core (1.0.1)
+    compass-core (1.0.3)
       multi_json (~> 1.0)
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
@@ -64,7 +64,7 @@ GEM
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
     fast-stemmer (1.0.2)
-    ffi (1.9.10)
+    ffi (1.13.1)
     git (1.3.0)
     hitimes (1.2.2)
     jekyll (2.5.3)
@@ -100,7 +100,7 @@ GEM
     mercenary (0.3.5)
     method_source (0.8.2)
     mini_portile2 (2.4.0)
-    multi_json (1.11.2)
+    multi_json (1.15.0)
     multipart-post (2.0.0)
     nap (1.1.0)
     nokogiri (1.10.8)
@@ -122,14 +122,14 @@ GEM
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
     rake (12.3.3)
-    rb-fsevent (0.9.5)
-    rb-inotify (0.9.5)
-      ffi (>= 0.5.0)
-    rdiscount (2.1.7)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rdiscount (2.2.0.2)
     redcarpet (3.3.4)
     ref (2.0.0)
     safe_yaml (1.0.4)
-    sass (3.4.16)
+    sass (3.4.25)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -148,6 +148,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   RedCloth
@@ -162,4 +163,4 @@ DEPENDENCIES
   rdiscount
 
 BUNDLED WITH
-   1.15.3
+   2.2.1


### PR DESCRIPTION
After the rabbit hole of issues we faced yesterday, @pepopowitz, I decided to zoom back and think about why this might be happening. I figured that the Bundler version in the `Gemfile.lock` being so behind might be the issue, but I still ran into some problems with dependencies that needed native extensions (the compiler errors we were seeing yesterday).

So I updated the Bundler version and a select few dependencies that were failing, basically adding another one until the command succeeded. 

```sh
bundle update --bundler ffi rdiscount compass
```

I then ran `bundle pristine` to make sure things were actually installed as they would be on others' computers, cleaned the build directory, built the site, and served it locally:

```sh
bundle pristine
rm -rf _gh-pages
bundle exec rake build
bundle exec rake serve
```

Seems to work! Hopefully CI will be happy and your machine will cooperate too.