### PR TITLE
chore: update podcast owner email

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -926,7 +926,7 @@ podcast:
    - software development
    - open source
   author: Artsy Engineering
-  email: OpenSourceGroup@artsy.net
+  email: OpenSourceGroup@artsymail.com
   logo_url: https://artsy.github.io/images/podcast_logo.png
   episodes:
     - title: "0: Introducting Artsy Engineering Radio"


### PR DESCRIPTION
Corrects the email address of the podcast owner.

## Why?

If #640 doesn't get the podcast listed on Google, I think I'll need to submit it through Google Podcasts Manager to get better clarity into why it's not being accepted. [According to docs](https://support.google.com/podcast-publishers/answer/9479755?hl=en), that will be easier if I log into Podcasts Manager using the same email as the owner email defined in the RSS feed. 

Also, I don't think we get emails for `artsy.net` at `artsymail.com`, so it'd be good to correct this anyway.