### PR TITLE
fix: inline long markdown links

### DIFF
--- a/_posts/2021-01-06-introducing-artsy-engineering-radio.markdown
+++ b/_posts/2021-01-06-introducing-artsy-engineering-radio.markdown
@@ -16,8 +16,9 @@ hope is that this podcast will make it easy for more engineers at Artsy to contr
 Artsy Engineering.
 
 We'll release new episodes every other week. Our target episode length is 30 minutes. Some episodes will be
-technical and others less so. Because [we work in the open][open-source-by-default] it's easy for us to talk about
-our work in public.
+technical and others less so. Because
+[we work in the open](https://github.com/artsy/README/blob/master/culture/engineering-principles.md#open-source-by-default)
+it's easy for us to talk about our work in public.
 
 This isn't the first attempt at an Artsy engineering podcast! Our engineering team has attempted multiple times to
 start one. When [Jon][jon] went to create new Slack and Notion hubs, he found that both already existed. The
@@ -27,22 +28,19 @@ We're beating the fizzle this time, though. We've got momentum and enthusiasm on
 already published and we've got more lined up. Instead of tinkering with tooling we're focusing on making episodes,
 even if they aren't perfect. Like the software we build, the podcast will get better over time as we iterate.
 
-What do we have so far? In [episode 0][episode-0], [Jon][jon], [Matt][matt], and [Steve][steve] introduced the
-podcast and talked about what you can expect from future episodes. [Episode 1][episode-1] features a conversation
-with [Ash][ash] about facilitating meaningful and inclusive team meetings, and how meetings are part of building
-teams, trust, and systems. [Episode 2][episode-2] is a conversation between [Steve][steve] and [Ash][ash] about how
-Artsy hires engineers.
+What do we have so far? In
+[episode 0](https://podcasts.apple.com/us/podcast/0-introducing-artsy-engineering-radio/id1545870104?i=1000503035175),
+[Jon][jon], [Matt][matt], and [Steve][steve] introduced the podcast and talked about what you can expect from
+future episodes. [Episode 1][episode-1] features a conversation with [Ash][ash] about facilitating meaningful and
+inclusive team meetings, and how meetings are part of building teams, trust, and systems. [Episode 2][episode-2] is
+a conversation between [Steve][steve] and [Ash][ash] about how Artsy hires engineers.
 
 Find the first few episodes right now in your podcast player. Watch for future episodes in your feed and we'll
 announce them [on Twitter][twitter] when they're released.
 
 [apple-podcasts]: https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104
 [spotify]: https://open.spotify.com/show/0gJYxpqN6P11dbjNw8VT2a?si=L4TWDrQETwuVO6JR1SOZTQ
-[open-source-by-default]:
-  https://github.com/artsy/README/blob/master/culture/engineering-principles.md#open-source-by-default
 [jon]: https://artsy.github.io/author/jonallured/
-[episode-0]:
-  https://podcasts.apple.com/us/podcast/0-introducing-artsy-engineering-radio/id1545870104?i=1000503035175
 [episode-1]: https://podcasts.apple.com/us/podcast/1-how-to-have-good-meetings/id1545870104?i=1000503035176
 [episode-2]: https://podcasts.apple.com/us/podcast/2-how-artsy-hires-engineers/id1545870104?i=1000504558896
 [matt]: https://artsy.github.io/author/matt-dole/

--- a/_posts/2021-01-06-introducing-artsy-engineering-radio.markdown
+++ b/_posts/2021-01-06-introducing-artsy-engineering-radio.markdown
@@ -15,6 +15,8 @@ There are a ton of amazing engineers here at Artsy and we're excited for you to 
 hope is that this podcast will make it easy for more engineers at Artsy to contribute to the public persona of
 Artsy Engineering.
 
+<!-- more -->
+
 We'll release new episodes every other week. Our target episode length is 30 minutes. Some episodes will be
 technical and others less so. Because
 [we work in the open](https://github.com/artsy/README/blob/master/culture/engineering-principles.md#open-source-by-default)


### PR DESCRIPTION
The longer markdown links were getting split into two lines when the source was auto-formatted, which resulted in them not working. 

This inlines line the longer links.