### PR TITLE
feat: add show links to feed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,11 @@ namespace :podcast do
       file_byte_length: "#{filesize}"
       duration: "#{duration}"
       credits: ""
+      links:
+        - title: "links are optional"
+          url: "https://TODO"
+        - title: "please remove the links property if there are none"
+          url: "https://TODO"
 EOS
 
     File.open('_config.yml', 'a') do |file|

--- a/_config.yml
+++ b/_config.yml
@@ -950,3 +950,12 @@ podcast:
       file_byte_length: "35648825"
       duration: "00:35:36"
       credits: "Ash Furrow & Steve Hicks"
+      links: 
+        - title: "How Artsy Hires Engineers by Ash Furrow, Lily Pace, & Steve Hicks"
+          url: "https://artsy.github.io/blog/2019/01/23/artsy-engineering-hiring/"
+        - title: "Learning from Artsy: How to hire awesome engineers by Brennan Moore"
+          url: "https://42hire.com/learning-from-artsy-how-to-hire-awesome-engineers-c772e498bb6c"
+        - title: "Interviewing, applying and getting your first job in iOS by Orta Therox"
+          url: "https://artsy.github.io/blog/2016/01/30/iOS-Junior-Interviews/"
+        - title: "Artsy jobs"
+          url: "https://www.artsy.net/jobs"

--- a/podcast.xml
+++ b/podcast.xml
@@ -59,6 +59,20 @@ exclude_from_search: true
         <itunes:image href="{{ site.podcast.logo_url }}" />
         <itunes:duration>{{ episode.duration }}</itunes:duration>
         <itunes:keywords>{{ site.podcast.keywords | join:', ' }}</itunes:keywords>
+        {% if episode.links %}
+          <content:encoded><![CDATA[
+            <strong>Links:</strong>
+
+            <ul>
+              {% for link in episode.links %}
+                <li>
+                  <a href="{{ link.url}}">{{link.title}}</a>
+                </li>
+              {% endfor %}
+            </ul>
+            ]]>
+          </content:encoded>
+        {% endif %}
       </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
This PR adds the ability to specify links for a specific episode in the config. It also adds notes to episode 2. 

The links get attached to the `content:encoded` element of the item in podcast.xml as formatted html that looks like this: 

![image](https://user-images.githubusercontent.com/1627089/104067720-4aca9980-51c9-11eb-90fa-f2a3807ad602.png)

That element gets rendered in the podcast player, usually as the details that show up when an episode is playing. 
