### PR TITLE
feat: Testing a github action to mark/close stale requested posts

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark/close stale requested posts
+
+on:
+  schedule:
+  - cron: "*/10 * * * MON-FRI"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        debug-only: true
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is light on activity. Feel free to comment if you are inspired to write this blog post!'
+        close-issue-message: 'Closing this issue due to inactivity. Feel free to reopen if you are inspired to write this blog post!'
+        days-before-stale: 180
+        skip-stale-pr-message: true
+        only-labels: Requested Post


### PR DESCRIPTION
@dblandin and I were doing some grooming of requested-post issues and noticed we have some old ones. We thought it might be good to keep this issue list relatively clean.

Introduces the [stale](https://github.com/actions/stale) action to mark stale/close inactive requested post issues.

Currently set up with `debug-only:true` and a very-frequent cron to test it out.