### PR TITLE
feat: bump up max number of operations for stale requested posts action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,3 +19,4 @@ jobs:
         days-before-stale: 180
         skip-stale-pr-message: true
         only-labels: Requested Post
+        operations-per-run: 100


### PR DESCRIPTION
The action added in #655 ran, but it didn't reach completion due to hitting a limit on number of operations.

This ups the limit so we can see it reach completion before turning off debug mode.