### PR TITLE
feat: enable stale requested-post action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
     - uses: actions/stale@v3
       with:
-        debug-only: true
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is light on activity. Feel free to comment if you are inspired to write this blog post!'
         close-issue-message: 'Closing this issue due to inactivity. Feel free to reopen if you are inspired to write this blog post!'


### PR DESCRIPTION
The action to mark/close stale requested-post issues [did what we wanted it to](https://github.com/artsy/artsy.github.io/actions/runs/549179456), so this PR turns off debug-only for the action.
