### PR TITLE
feat: throttle down the stale requested-posts action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark/close stale requested posts
 
 on:
   schedule:
-  - cron: "*/10 * * * MON-FRI"
+  - cron: "0 17 * * MON-FRI"
 
 jobs:
   stale:


### PR DESCRIPTION
Given #659 will be open for a few days, this PR updates the stale requested-posts action to run once a day instead of every ten minutes, to avoid hitting the GitHub API unnecessarily. 

Once this PR is merged, I'll remove the scheduling update from #658.