### PR TITLE
feat: Add ability to include canonical url field from posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
   <meta property="og:image" content="http://artsy.github.io/images/artsy_oss_image.png" />
   <meta property="og:image:type" content="image/png" />
 
-  {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
+  {% capture canonical %}{% if page.canonical %}{{ page.canonical }}{% else %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endif %}{% endcapture %}
   <link rel="canonical" href="{{ canonical }}">
   <link rel="alternate" type="application/rss+xml" title="Artsy Engineering Blog" href="/feed">
   <link rel="alternate" type="application/atom+xml" title="Podcast Feed" href="/podcast.xml" />


### PR DESCRIPTION
@pepopowitz and I added the capability to handle a canonical URL field from posts. If `canonical` is included in the post, it will be added to the page. Otherwise, the canonical URL will be generated as before.