### PR TITLE
fix: Remove padding on last line of blockquote

### DIFF
--- a/_sass/epic.scss
+++ b/_sass/epic.scss
@@ -67,6 +67,10 @@ article.post {
     padding-bottom: 1.25em;
   }
 
+  blockquote > p:last-child {
+    padding-bottom: 0
+  }
+
   p > img {
     width: 100%;
     text-align: center;


### PR DESCRIPTION
Overrided padding on last line of blockquote to 0px.

Before:
<img width="835" alt="Screen Shot 2021-02-11 at 8 33 22 AM" src="https://user-images.githubusercontent.com/9466631/107658878-d198e900-6c43-11eb-9d4e-93a703c543cf.png">

After:
<img width="827" alt="Screen Shot 2021-02-11 at 8 34 40 AM" src="https://user-images.githubusercontent.com/9466631/107659060-fee59700-6c43-11eb-8f6a-8f8c4874c046.png">
