### PR TITLE
fix: escape descriptions in podcast feed

### DIFF
--- a/podcast.xml
+++ b/podcast.xml
@@ -48,14 +48,14 @@ exclude_from_search: true
       <item>
         <title>{{ episode.title }}</title>
         <pubDate>{{ episode.date | date_to_rfc822 }}</pubDate>
-        <description>{{ episode.description | replace:'&amp;mdash;','-' }}</description>
+        <description>{{ episode.description | xml_escape | replace:'&amp;mdash;','-' }}</description>
 
         <enclosure url="{{ episode.url }}" length="{{ episode.file_byte_length }}" type="audio/mpeg" />
         <link>{{ episode.url }}</link>
         <guid>{{ episode.url }}</guid>
 
         <itunes:author>{{ episode.credits | xml_escape }}</itunes:author>
-        <itunes:summary>{{ episode.description | replace:'&amp;mdash;','-' }}</itunes:summary>
+        <itunes:summary>{{ episode.description | xml_escape | replace:'&amp;mdash;','-' }}</itunes:summary>
         <itunes:image href="{{ site.podcast.logo_url }}" />
         <itunes:duration>{{ episode.duration }}</itunes:duration>
         <itunes:keywords>{{ site.podcast.keywords | join:', ' }}</itunes:keywords>


### PR DESCRIPTION
Last week's episode didn't show up in google podcasts, and it looks like it's because the feed isn't valid:

![image](https://user-images.githubusercontent.com/1627089/112853827-de965e00-9072-11eb-9d76-6247520bbcfa.png)


The error is coming from unescaped ampersands: 

![image](https://user-images.githubusercontent.com/1627089/112853655-b27add00-9072-11eb-84c5-8eb85b0d5380.png)

This escapes both places we emit the `description`.
