### PR TITLE
chore: adopt inclusive language - egregious cases of master

### DIFF
--- a/_posts/2012-05-27-using-jenkins-for-ruby-and-ruby-on-rails-teams.markdown
+++ b/_posts/2012-05-27-using-jenkins-for-ruby-and-ruby-on-rails-teams.markdown
@@ -6,21 +6,34 @@ comments: true
 categories: [Jenkins, Automation, Testing]
 author: db
 ---
-The [Jenkins CI](http://jenkins-ci.org) project has grown tremendously in the past few months. There're now hundreds of plugins and an amazing engaged community. Artsy is a happy user and proud contributor to this effort with the essential [jenkins-ansicolor plugin](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin), eliminating boring console output since 2011.
 
-We are a continuous integration, deployment and devops shop and have been using Jenkins for over a year now. We've shared our experience at the [Jenkins User Conference 2012](http://www.cloudbees.com/juc2012.cb) in [a presentation](http://www.slideshare.net/dblockdotorg/graduating-to-jenkins-ci-for-rubyonrails-teams). This blog post is an overview of how to get started with Jenkins for Ruby(-on-Rails) teams.
+The [Jenkins CI](http://jenkins-ci.org) project has grown tremendously in the past few months. There're now
+hundreds of plugins and an amazing engaged community. Artsy is a happy user and proud contributor to this effort
+with the essential [jenkins-ansicolor plugin](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin),
+eliminating boring console output since 2011.
+
+We are a continuous integration, deployment and devops shop and have been using Jenkins for over a year now. We've
+shared our experience at the [Jenkins User Conference 2012](http://www.cloudbees.com/juc2012.cb) in
+[a presentation](http://www.slideshare.net/dblockdotorg/graduating-to-jenkins-ci-for-rubyonrails-teams). This blog
+post is an overview of how to get started with Jenkins for Ruby(-on-Rails) teams.
 
 ![/images/2012-05-27-using-jenkins-for-ruby-on-rails-teams/jenkins.png](Artsy Jenkins CI)
 
 <!-- more -->
 
-When Artsy had only three engineers, we hesitated to deploy Jenkins. The CI server was written in Java (i.e. wasn't written in Ruby). We feared introducing excessive infrastructure too early. In retrospect, we were not in the business of building CI infrastructure, so not using Jenkins was a mistake. Since we adopted it, Jenkins has been operating painlessly and scaled nicely as our needs continued to grow.
+When Artsy had only three engineers, we hesitated to deploy Jenkins. The CI server was written in Java (i.e. wasn't
+written in Ruby). We feared introducing excessive infrastructure too early. In retrospect, we were not in the
+business of building CI infrastructure, so not using Jenkins was a mistake. Since we adopted it, Jenkins has been
+operating painlessly and scaled nicely as our needs continued to grow.
 
-Today, we run a single virtual server on [Linode](http://www.linode.com) as our master Jenkins and have 8 Linode slaves. These are all $19 per month plans. Our usage is variable: few builds in the middle of the night and a very high number of builds during the day, so we're planning on trying to build a Jenkins-slave on-demand system on AWS eventually.
+Today, we run a single virtual server on [Linode](http://www.linode.com) as our Jenkins controller and have 8
+Linode agents. These are all $19 per month plans. Our usage is variable: few builds in the middle of the night and
+a very high number of builds during the day, so we're planning on trying to build a Jenkins-agent on-demand system
+on AWS eventually.
 
-Setting up a Jenkins master is straightforward.
+Setting up a Jenkins controller is straightforward.
 
-``` bash
+```bash
 useradd -m jenkins -p [password] -s /bin/bash
 addgroup jenkins sudo
 wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add –
@@ -29,13 +42,24 @@ sudo aptitude update
 sudo aptitude install jenkins
 ```
 
-We change Jenkins port in `/etc/default/jenkins`, add the machine to DNS and update the Jenkins URL to an externally visible one in the "Manage Jenkins", "Configure System" menu. We enable and use "Matrix-Based Security" with a single user that all developers share and give the user permission to do everything in the same UI. Finally, we configure the Git Plugin with a global username and e-mail from our shared IT account that has Github access, setup a Github Web Hook and SMTP E-Mail notifications. Restarting Jenkins from the command line with `sudo service jenkins restart` completes the initial setup.
+We change Jenkins port in `/etc/default/jenkins`, add the machine to DNS and update the Jenkins URL to an
+externally visible one in the "Manage Jenkins", "Configure System" menu. We enable and use "Matrix-Based Security"
+with a single user that all developers share and give the user permission to do everything in the same UI. Finally,
+we configure the Git Plugin with a global username and e-mail from our shared IT account that has Github access,
+setup a Github Web Hook and SMTP E-Mail notifications. Restarting Jenkins from the command line with
+`sudo service jenkins restart` completes the initial setup.
 
-It's also a good idea to setup Jenkins configuration backup with [thinBackup](https://wiki.jenkins-ci.org/display/JENKINS/thinBackup), install [AnsiColor](http://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin) and, of course, enable [Chuck Norris](http://wiki.hudson-ci.org/display/HUDSON/ChuckNorris+Plugin).
+It's also a good idea to setup Jenkins configuration backup with
+[thinBackup](https://wiki.jenkins-ci.org/display/JENKINS/thinBackup), install
+[AnsiColor](http://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin) and, of course, enable
+[Chuck Norris](http://wiki.hudson-ci.org/display/HUDSON/ChuckNorris+Plugin).
 
-A typical Ruby development environment includes [RVM](https://rvm.io/), a working GIT client and a Github SSH key. We install these under our `jenkins` user manually on the first slave Linode and then clone slaves when we need more. RVM setup includes entries in `~/.bash_profile`, so a Jenkins job for a Ruby project can load that file and execute commands, including `rake`.
+A typical Ruby development environment includes [RVM](https://rvm.io/), a working GIT client and a Github SSH key.
+We install these under our `jenkins` user manually on the first agent Linode and then clone agents when we need
+more. RVM setup includes entries in `~/.bash_profile`, so a Jenkins job for a Ruby project can load that file and
+execute commands, including `rake`.
 
-``` bash
+```bash
 #!/bin/bash
 source ~/.bash_profile
 rvm use 1.9.2
@@ -44,9 +68,13 @@ bundle install
 bundle exec rake
 ```
 
-Our default Ruby project Rake task is `test:ci`. We run Jasmine and Capybara tests using a real browser, so we need to redirect all visible output to an X-Windows Virtual Frame Buffer ([XVFB](http://www.xfree86.org/4.0.1/Xvfb.1.html)). This can be done by setting an `ENV` variable inside a Rake task. Our test target also [organizes our tests in suites](http://artsy.github.com/blog/2012/05/15/how-to-organize-over-3000-rspec-specs-and-retry-test-failures/).
+Our default Ruby project Rake task is `test:ci`. We run Jasmine and Capybara tests using a real browser, so we need
+to redirect all visible output to an X-Windows Virtual Frame Buffer
+([XVFB](http://www.xfree86.org/4.0.1/Xvfb.1.html)). This can be done by setting an `ENV` variable inside a Rake
+task. Our test target also
+[organizes our tests in suites](http://artsy.github.com/blog/2012/05/15/how-to-organize-over-3000-rspec-specs-and-retry-test-failures/).
 
-``` ruby
+```ruby
 namespace :test do
   task :specs, [ :display ] => :environment do |t, args|
    ENV['DISPLAY'] = args[:display] if args[:display]
@@ -73,7 +101,7 @@ end
 
 A successful CI test run will trigger a deployment to a staging environment on Heroku.
 
-``` ruby
+```ruby
 namespace :deploy do
   task :staging => :environment do
     system!("bundle exec heroku maintenance:on --app=app-staging")
@@ -83,9 +111,10 @@ namespace :deploy do
 end
 ```
 
-You'll notice that we execute system commands with `system!`. Unlike the usual `system` method, our wrapper raises an exception when a command returns a non-zero error code to abort execution.
+You'll notice that we execute system commands with `system!`. Unlike the usual `system` method, our wrapper raises
+an exception when a command returns a non-zero error code to abort execution.
 
-``` ruby
+```ruby
 def system!(cmdline)
   logger.info("[#{Time.now}] #{cmdline}")
   rc = system(cmdline)
@@ -95,7 +124,7 @@ end
 
 Our production deployment task is also a Jenkins job.
 
-``` ruby
+```ruby
 namespace :deploy do
   task :production => :environment do
     system!("git push git@heroku.com:app-production.git origin/production:master")
@@ -103,6 +132,10 @@ namespace :deploy do
 end
 ```
 
-We don't want any downtime on our production environment, so we don't turn Heroku maintance on. Our staging deployment task also includes copying production data to staging, so we chose to enable maintenance to avoid people hitting the test environment while it's being built and may be in a half-baked state.
+We don't want any downtime on our production environment, so we don't turn Heroku maintenance on. Our staging
+deployment task also includes copying production data to staging, so we chose to enable maintenance to avoid people
+hitting the test environment while it's being built and may be in a half-baked state.
 
-Finally, we also run production daily cron-like tasks via Jenkins. It gives us email notifications, console output and the ability to manually trigger them. Centralizing operations in the same environment as CI creates truly continuous integration, deployment and operations.
+Finally, we also run production daily cron-like tasks via Jenkins. It gives us email notifications, console output
+and the ability to manually trigger them. Centralizing operations in the same environment as CI creates truly
+continuous integration, deployment and operations.

--- a/_posts/2012-05-27-using-jenkins-for-ruby-and-ruby-on-rails-teams.markdown
+++ b/_posts/2012-05-27-using-jenkins-for-ruby-and-ruby-on-rails-teams.markdown
@@ -139,3 +139,8 @@ hitting the test environment while it's being built and may be in a half-baked s
 Finally, we also run production daily cron-like tasks via Jenkins. It gives us email notifications, console output
 and the ability to manually trigger them. Centralizing operations in the same environment as CI creates truly
 continuous integration, deployment and operations.
+
+---
+
+_Editor's Note: This post has been updated as part of an effort to adopt more inclusive language across Artsy's
+GitHub repositories and editorial content ([RFC](https://github.com/artsy/README/issues/427))._

--- a/_posts/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2.markdown
+++ b/_posts/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2.markdown
@@ -78,3 +78,8 @@ improvements to be made:
 - Cooler still would be for the EC2 plugin to take advantage of Amazon's
   [spot pricing](http://aws.amazon.com/ec2/spot-instances/). Though not supported at the moment, it would allow us
   to spend a fraction as much (or spend the same amount, but on more powerful resources).
+
+---
+
+_Editor's Note: This post has been updated as part of an effort to adopt more inclusive language across Artsy's
+GitHub repositories and editorial content ([RFC](https://github.com/artsy/README/issues/427))._

--- a/_posts/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2.markdown
+++ b/_posts/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2.markdown
@@ -1,55 +1,80 @@
 ---
 layout: post
-title: "On-Demand Jenkins Slaves with Amazon EC2"
+title: "On-Demand Jenkins Agents with Amazon EC2"
 date: 2012-07-10 13:30
 comments: true
 categories: [Jenkins, Testing, Continuous Integration, EC2]
 author: [joey, frank]
 ---
 
-The [Artsy](http://artsy.net) team faithfully uses [Jenkins](http://jenkins-ci.org) for continuous integration. [As we've described before](http://artsy.github.com/blog/2012/05/27/using-jenkins-for-ruby-and-ruby-on-rails-teams/), our Jenkins master and 8 slaves run on Linode. This arrangement has at least a few drawbacks:
+The [Artsy](http://artsy.net) team faithfully uses [Jenkins](http://jenkins-ci.org) for continuous integration.
+[As we've described before](http://artsy.github.com/blog/2012/05/27/using-jenkins-for-ruby-and-ruby-on-rails-teams/),
+our Jenkins controller and 8 agents run on Linode. This arrangement has at least a few drawbacks:
 
-* Our Linode servers are manually configured. They require frequent maintenance, and inconsistencies lead to surprising build failures.
-* The fixed set of slaves don't match the pattern of our build jobs: jobs get backed up during the day, but servers are mostly unused overnight and on weekends.
+- Our Linode servers are manually configured. They require frequent maintenance, and inconsistencies lead to
+  surprising build failures.
+- The fixed set of agents don't match the pattern of our build jobs: jobs get backed up during the day, but servers
+  are mostly unused overnight and on weekends.
 
-The [Amazon EC2 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin) allowed us to replace those slaves with a totally scripted environment. Now, slaves are spun up in the cloud whenever build jobs need them.
+The [Amazon EC2 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin) allowed us to replace those
+agents with a totally scripted environment. Now, agents are spun up in the cloud whenever build jobs need them.
 
 <!-- more -->
 
-To set up the build slave's Amazon Machine Image (AMI), we started from an [official Ubuntu 11.10](http://cloud-images.ubuntu.com/releases/oneiric/release/) (Oneiric Ocelot) AMI, ran initialization scripts to set up our build dependencies (MongoDB, Redis, ImageMagick, Firefox, RVM, NVM, etc.), packaged our modified instance into its own AMI, and then set up the EC2 Plugin to launch instances from this custom AMI.
+To set up the build agent's Amazon Machine Image (AMI), we started from an
+[official Ubuntu 11.10](http://cloud-images.ubuntu.com/releases/oneiric/release/) (Oneiric Ocelot) AMI, ran
+initialization scripts to set up our build dependencies (MongoDB, Redis, ImageMagick, Firefox, RVM, NVM, etc.),
+packaged our modified instance into its own AMI, and then set up the EC2 Plugin to launch instances from this
+custom AMI.
 
-Our AMI setup steps are captured entirely in a [GitHub gist](https://gist.github.com/3085368), but because our build requirements are specific to our applications and frameworks, most organizations will need to modify these scripts to their own use cases. Given that caveat, here's how we went from base Ubuntu AMI to custom build slave AMI:
+Our AMI setup steps are captured entirely in a [GitHub gist](https://gist.github.com/3085368), but because our
+build requirements are specific to our applications and frameworks, most organizations will need to modify these
+scripts to their own use cases. Given that caveat, here's how we went from base Ubuntu AMI to custom build agent
+AMI:
 
-1. We [launched](https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-4dad7424) an Ubuntu 11.10 AMI `4dad7424` via the AWS console.
-2. Once the instance was launched, we logged in with the SSH key we generated during setup.
-3. We ran the following commands to configure the instance:
+1.  We [launched](https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-4dad7424) an Ubuntu 11.10
+    AMI `4dad7424` via the AWS console.
+2.  Once the instance was launched, we logged in with the SSH key we generated during setup.
+3.  We ran the following commands to configure the instance:
 
         curl -L https://raw.github.com/gist/3085368/_base-setup.sh | sudo bash -s
         sudo su -l jenkins
         curl -L https://raw.github.com/gist/3085368/_jenkins-user-setup.sh | bash -s
 
-4. From the "Instances" tab of the AWS Console, we chose the now-configured instance, and from the "Instance Actions" dropdown, selected "Stop", followed by "Create Image (EBS AMI)".
+4.  From the "Instances" tab of the AWS Console, we chose the now-configured instance, and from the "Instance
+    Actions" dropdown, selected "Stop", followed by "Create Image (EBS AMI)".
 
-Next we installed the Amazon EC2 Plugin on our Jenkins master, and entered the following configuration arguments for the plugin. (Replace the AMI ID with your own, the result of Step 4 above.)
+Next we installed the Amazon EC2 Plugin on our Jenkins controller, and entered the following configuration
+arguments for the plugin. (Replace the AMI ID with your own, the result of Step 4 above.)
 
-![/images/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2/ec2-plugin-config.png](Jenkins EC2 Plugin configuration)
+![/images/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2/ec2-plugin-config.png](Jenkins EC2 Plugin
+configuration)
 
-New build slaves began spawning immediately in response to job demand! Our new "Computers" page on Jenkins looks like this:
+New build agents began spawning immediately in response to job demand! Our new "Computers" page on Jenkins looks
+like this:
 
 ![/images/2012-07-10-on-demand-jenkins-slaves-with-amazon-ec2/computer-list.png](Jenkins computer list)
 
-We have the option of provisioning a new build slave via a single click, but so far, this hasn't been necessary, since slaves have automatically scaled up and down with demand. We average around 4-8 build slaves during the day, and 0-1 overnight and on weekends.
+We have the option of provisioning a new build agent via a single click, but so far, this hasn't been necessary,
+since agents have automatically scaled up and down with demand. We average around 4-8 build agents during the day,
+and 0-1 overnight and on weekends.
 
 ## Outcome and Next Steps
 
 This arrangement hasn't been in place for long, but we're excited about the benefits it's already delivered:
 
-* Builds now take a predictable amount of time, since slaves automatically scale up to match demand.
-* Slaves offer a more consistent and easily maintained configuration, so there are fewer spurious failures.
-* Despite higher costs on EC2, we hope to spend about the same (or maybe even less) now that we'll need to operate only the master server during periods of inactivity (like nights and weekends).
+- Builds now take a predictable amount of time, since agents automatically scale up to match demand.
+- Agents offer a more consistent and easily maintained configuration, so there are fewer spurious failures.
+- Despite higher costs on EC2, we hope to spend about the same (or maybe even less) now that we'll need to operate
+  only the controller server during periods of inactivity (like nights and weekends).
 
-As proponents of _automating the hard stuff_, we get a real kick out of watching identical slaves spin up as builds trickle in each morning, then disappear as the queue quiets down in the evening. Still, there are a few improvements to be made:
+As proponents of _automating the hard stuff_, we get a real kick out of watching identical agents spin up as builds
+trickle in each morning, then disappear as the queue quiets down in the evening. Still, there are a few
+improvements to be made:
 
-* Our canonical slave's configuration should be scripted with [Chef](http://www.opscode.com/chef/).
-* Sharp-eyed readers will notice that our Jenkins master is still a Linode server. It might benefit from the same type of scripted configuration as the slaves.
-* Cooler still would be for the EC2 plugin to take advantage of Amazon's [spot pricing](http://aws.amazon.com/ec2/spot-instances/). Though not supported at the moment, it would allow us to spend a fraction as much (or spend the same amount, but on more powerful resources).
+- Our canonical agent's configuration should be scripted with [Chef](http://www.opscode.com/chef/).
+- Sharp-eyed readers will notice that our Jenkins controller is still a Linode server. It might benefit from the
+  same type of scripted configuration as the agents.
+- Cooler still would be for the EC2 plugin to take advantage of Amazon's
+  [spot pricing](http://aws.amazon.com/ec2/spot-instances/). Though not supported at the moment, it would allow us
+  to spend a fraction as much (or spend the same amount, but on more powerful resources).

--- a/_posts/2012-10-10-artsy-technology-stack.markdown
+++ b/_posts/2012-10-10-artsy-technology-stack.markdown
@@ -7,66 +7,106 @@ categories: [Technology]
 author: db
 series: Artsy Tech Stack
 ---
-The public launch of Artsy via the [New York Times](http://www.nytimes.com/2012/10/09/arts/design/artsy-is-mapping-the-world-of-art-on-the-web.html) is a good opportunity to describe our current technology stack.
 
-What you see when you go to [Artsy](http://artsy.net) is a website built with [Backbone.js](http://backbonejs.org/) and written in [CoffeeScript](http://coffeescript.org/). It renders JSON data from [Ruby on Rails](http://rubyonrails.org/), [Ruby Grape](https://github.com/intridea/grape) and [Node.js](http://nodejs.org/) services. Text search is powered by [Apache Solr](http://lucene.apache.org/solr/). We also have an [iOS](https://developer.apple.com/devcenter/ios/index.action) application that talks to the same back-end Ruby API. We run all our web processes on [Heroku](http://www.heroku.com/) and all job queues on [Amazon EC2](http://aws.amazon.com/). Our data store is [MongoDB](http://www.mongodb.org/), operated by [MongoHQ](https://mongohq.com/) and we have some [Redis](http://redis.io/) instances. Our assets, including images, are served from [Amazon S3](http://aws.amazon.com/s3/) via the [CloudFront CDN](http://aws.amazon.com/cloudfront/). We heavily rely on [Memcached](http://memcached.org/) Heroku addon and we use [SendGrid](http://sendgrid.com/) and [MailChimp](http://mailchimp.com/) to send e-mail. Systems are monitored by a combination of [New Relic](http://newrelic.com/) and [Pingdom](https://www.pingdom.com/). All of this is built, tested and deployed with [Jenkins](http://jenkins-ci.org/).
+The public launch of Artsy via the
+[New York Times](http://www.nytimes.com/2012/10/09/arts/design/artsy-is-mapping-the-world-of-art-on-the-web.html)
+is a good opportunity to describe our current technology stack.
+
+What you see when you go to [Artsy](http://artsy.net) is a website built with [Backbone.js](http://backbonejs.org/)
+and written in [CoffeeScript](http://coffeescript.org/). It renders JSON data from
+[Ruby on Rails](http://rubyonrails.org/), [Ruby Grape](https://github.com/intridea/grape) and
+[Node.js](http://nodejs.org/) services. Text search is powered by [Apache Solr](http://lucene.apache.org/solr/). We
+also have an [iOS](https://developer.apple.com/devcenter/ios/index.action) application that talks to the same
+back-end Ruby API. We run all our web processes on [Heroku](http://www.heroku.com/) and all job queues on
+[Amazon EC2](http://aws.amazon.com/). Our data store is [MongoDB](http://www.mongodb.org/), operated by
+[MongoHQ](https://mongohq.com/) and we have some [Redis](http://redis.io/) instances. Our assets, including images,
+are served from [Amazon S3](http://aws.amazon.com/s3/) via the [CloudFront CDN](http://aws.amazon.com/cloudfront/).
+We heavily rely on [Memcached](http://memcached.org/) Heroku addon and we use [SendGrid](http://sendgrid.com/) and
+[MailChimp](http://mailchimp.com/) to send e-mail. Systems are monitored by a combination of
+[New Relic](http://newrelic.com/) and [Pingdom](https://www.pingdom.com/). All of this is built, tested and
+deployed with [Jenkins](http://jenkins-ci.org/).
 
 <img src="/images/2012-10-10-artsy-technology-stack/artsy-infrastructure.png">
 
-In this post I'll go in depth in our current system architecture and tell you the story about how these parts all came together.
+In this post I'll go in depth in our current system architecture and tell you the story about how these parts all
+came together.
 
 <!-- more -->
 
-Early Prototypes
-----------------
+## Early Prototypes
 
-Artsy early prototypes in 2010 consisted of a combination of PHP and Java web services running on JBoss and backed by a MySQL database. The system had more similarities with a large transactional banking application than a consumer website.
+Artsy early prototypes in 2010 consisted of a combination of PHP and Java web services running on JBoss and backed
+by a MySQL database. The system had more similarities with a large transactional banking application than a
+consumer website.
 
-In early 2011 we rebooted the project on Ruby on Rails. RDBMS storage was replaced with NoSQL MongoDB. A [video](http://www.10gen.com/presentations/MongoNYC-2012/Using-MongoDB-to-Build-Artsy) was recorded at MongoNYC 2012 that goes in depth into this specific choice.
+In early 2011 we rebooted the project on Ruby on Rails. RDBMS storage was replaced with NoSQL MongoDB. A
+[video](http://www.10gen.com/presentations/MongoNYC-2012/Using-MongoDB-to-Build-Artsy) was recorded at MongoNYC
+2012 that goes in depth into this specific choice.
 
-Artsy Architecture Today
--------------------------
+## Artsy Architecture Today
 
-Having only a handful of engineers, our goal has always been to keep the number of moving parts to an absolute minimum. With a few new engineers we were able to expand things a bit.
+Having only a handful of engineers, our goal has always been to keep the number of moving parts to an absolute
+minimum. With a few new engineers we were able to expand things a bit.
 
-Artsy Website Front-End
-------------------------
+## Artsy Website Front-End
 
-The Artsy website is a responsive [Backbone.js](http://backbonejs.org/) application written in [CoffeeScript](http://coffeescript.org/) and [SASS](http://sass-lang.com/) and served from a Rails back-end. The generated JavaScript and CSS files are packaged and compressed with [Jammit](http://documentcloud.github.com/jammit/) and deployed to Amazon S3. The Rails app itself is a traditional MVC system that bootstraps application data and mostly serves SEO needs, such as meta tags, escaped fragments and page titles. Once the basic data has been rendered though, Backbone routing takes over and you're now navigating a client-side browser app with pushState support as available, swapping frames and rendering views using JST templates and JSON data returned from the API.
+The Artsy website is a responsive [Backbone.js](http://backbonejs.org/) application written in
+[CoffeeScript](http://coffeescript.org/) and [SASS](http://sass-lang.com/) and served from a Rails back-end. The
+generated JavaScript and CSS files are packaged and compressed with
+[Jammit](http://documentcloud.github.com/jammit/) and deployed to Amazon S3. The Rails app itself is a traditional
+MVC system that bootstraps application data and mostly serves SEO needs, such as meta tags, escaped fragments and
+page titles. Once the basic data has been rendered though, Backbone routing takes over and you're now navigating a
+client-side browser app with pushState support as available, swapping frames and rendering views using JST
+templates and JSON data returned from the API.
 
-Core API
---------
+## Core API
 
-The website talks to the nervous system of Artsy, a RESTful API built in Ruby and [Grape](https://github.com/intridea/grape).
+The website talks to the nervous system of Artsy, a RESTful API built in Ruby and
+[Grape](https://github.com/intridea/grape).
 
-In the early days we did a ton of domain-driven design and spent a lot of time modeling concepts such as *artist* or *artwork*. The API has read and write behavior for all our domain concepts. Probably 70% of it is pure CRUD doing [Mongoid](http://mongoid.org/) queries with a layer of access control in [CanCan](https://github.com/ryanb/cancan) and cache partitioning and binding using [Garner](http://confreaks.com/videos/986-goruco2012-from-zero-to-api-cache-w-grape-mongodb-in-10-minutes).
+In the early days we did a ton of domain-driven design and spent a lot of time modeling concepts such as _artist_
+or _artwork_. The API has read and write behavior for all our domain concepts. Probably 70% of it is pure CRUD
+doing [Mongoid](http://mongoid.org/) queries with a layer of access control in
+[CanCan](https://github.com/ryanb/cancan) and cache partitioning and binding using
+[Garner](http://confreaks.com/videos/986-goruco2012-from-zero-to-api-cache-w-grape-mongodb-in-10-minutes).
 
-Search Autocomplete
--------------------
+## Search Autocomplete
 
-The first iteration of the website's text search was powered by [mongoid_fulltext](https://github.com/artsy/mongoid_fulltext). Today we run an [Apache Solr](http://lucene.apache.org/solr/) master-slave environment hosted on EC2.
+The first iteration of the website's text search was powered by
+[mongoid_fulltext](https://github.com/artsy/mongoid_fulltext). Today we run an
+[Apache Solr](http://lucene.apache.org/solr/) leader-follower environment hosted on EC2.
 
-Offline Indexes
----------------
+## Offline Indexes
 
-The indexes that serve complex queries like related artists/artworks and filtered searches of artworks are all built offline. Our index-building system runs continuously, repeatedly pulling data from our production system to build the most out-of-date index. All of the most current indexes are imported back into production by a daily batch process and we swap the old indexes out atomically using [mongoid_collection_snapshot](https://github.com/aaw/mongoid_collection_snapshot).
+The indexes that serve complex queries like related artists/artworks and filtered searches of artworks are all
+built offline. Our index-building system runs continuously, repeatedly pulling data from our production system to
+build the most out-of-date index. All of the most current indexes are imported back into production by a daily
+batch process and we swap the old indexes out atomically using
+[mongoid_collection_snapshot](https://github.com/aaw/mongoid_collection_snapshot).
 
-One of such indexes a *similarity graph* that we query to produce most similar results on the website, other indexes serve filtering needs, etc. We run these processes nightly.
+One of such indexes a _similarity graph_ that we query to produce most similar results on the website, other
+indexes serve filtering needs, etc. We run these processes nightly.
 
-Admin Back-End and Partner CMS
-------------------------------
+## Admin Back-End and Partner CMS
 
-The Artsy CMS and the Admin system are two newer projects and serve the needs of our partners and our internal back-end needs, respectively. These are built on a thin [Node.js](http://nodejs.org) server that proxies requests to our API using [node-http-proxy](https://github.com/nodejitsu/node-http-proxy). They consist of a client-side Backbone.js application with assets packaged with [nap](https://github.com/craigspaeth/nap). This is a lot like our website, but completely decoupled from the main Rails application and sharing the same technology for both client and server with CoffeeScript and [Jade](http://jade-lang.com/).
+The Artsy CMS and the Admin system are two newer projects and serve the needs of our partners and our internal
+back-end needs, respectively. These are built on a thin [Node.js](http://nodejs.org) server that proxies requests
+to our API using [node-http-proxy](https://github.com/nodejitsu/node-http-proxy). They consist of a client-side
+Backbone.js application with assets packaged with [nap](https://github.com/craigspaeth/nap). This is a lot like our
+website, but completely decoupled from the main Rails application and sharing the same technology for both client
+and server with CoffeeScript and [Jade](http://jade-lang.com/).
 
+## Folio Partner App
 
-Folio Partner App
------------------
+Artsy makes a free iOS application, called [Folio](http://artsy.github.com/blog/categories/ios/), which lets our
+partners display their inventory at art fairs.
 
-Artsy makes a free iOS application, called [Folio](http://artsy.github.com/blog/categories/ios/), which lets our partners display their inventory at art fairs.
+Folio is a native iOS implementation. The interface is heavily skinned UIKit with CoreData for storage. Our network
+code was originally a thin layer on top of NSURLConnection, but for our forthcoming update, we’ve rewritten it to
+use [AFNetworking](https://github.com/AFNetworking/AFNetworking/). We manage external dependencies with
+[CocoaPods](https://github.com/CocoaPods/CocoaPods).
 
-Folio is a native iOS implementation. The interface is heavily skinned UIKit with CoreData for storage. Our network code was originally a thin layer on top of NSURLConnection, but for our forthcoming update, we’ve rewritten it to use [AFNetworking](https://github.com/AFNetworking/AFNetworking/). We manage external dependencies with [CocoaPods](https://github.com/CocoaPods/CocoaPods).
+## Want More Specifics? Have Questions?
 
-Want More Specifics? Have Questions?
-------------------------------------
-
-We hope you find this useful and are happy to describe any aspect of our system on this blog. Please ask questions below, we’ll be happy to answer them.
+We hope you find this useful and are happy to describe any aspect of our system on this blog. Please ask questions
+below, we’ll be happy to answer them.

--- a/_posts/2012-10-10-artsy-technology-stack.markdown
+++ b/_posts/2012-10-10-artsy-technology-stack.markdown
@@ -110,3 +110,8 @@ use [AFNetworking](https://github.com/AFNetworking/AFNetworking/). We manage ext
 
 We hope you find this useful and are happy to describe any aspect of our system on this blog. Please ask questions
 below, we’ll be happy to answer them.
+
+---
+
+_Editor's Note: This post has been updated as part of an effort to adopt more inclusive language across Artsy's
+GitHub repositories and editorial content ([RFC](https://github.com/artsy/README/issues/427))._


### PR DESCRIPTION
We have **a lot** of cases of [`master` in blog posts](https://github.com/artsy/artsy.github.io/search?q=master). Most of them are links to repos, many discuss the `master` branch in text, and then there were a few usages in regards to master-slave replication. 

This PR updates those more egregious master-slave usages according to the product's replacement for that language: [Jenkins now uses controller-agent](https://www.jenkins.io/doc/book/using/using-agents/) and [Solr now uses leader-follower](https://solr.apache.org/guide/8_11/index-replication.html). 

Each updated article includes a footer indicating the original content has been updated for inclusive language. Example: 

![image](https://user-images.githubusercontent.com/1627089/146209351-7a1ee71d-94f7-4be7-9670-973a84c0fc88.png)

---

I'd love to hear opinions on what we should do about the remaining usages of `master`.