### PR TITLE
chore: update year in review authors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -275,6 +275,11 @@ authors:
     twitter: anna_carey
     site: https://www.annajcarey.com
 
+  devon:
+    name: Devon Blandin
+    github: dblandin
+    twitter: dblandin
+
 series:
   - title: "React Native at Artsy"
     url: series/react-native-at-artsy/

--- a/_config.yml
+++ b/_config.yml
@@ -174,7 +174,7 @@ authors:
   artsy:
     name: Artsy
 
-  artsy_engineering:
+  artsy-engineering:
     name: The Artsy Engineering Team
     site: http://artsy.github.io
     twitter: ArtsyOpenSource

--- a/_drafts/artsy-engineering-culture-2017.md
+++ b/_drafts/artsy-engineering-culture-2017.md
@@ -3,7 +3,7 @@ layout: post_longform
 title: Artsy's Culture Stack, 2017
 date: 2017-03-05
 categories: [Technology, eigen, force, gravity]
-author: [orta, artsy_engineering]
+author: [orta, artsy-engineering]
 series: Artsy Tech Stack
 ---
 

--- a/_posts/2017-04-14-artsy-technology-stack-2017.md
+++ b/_posts/2017-04-14-artsy-technology-stack-2017.md
@@ -3,7 +3,7 @@ layout: epic
 title: Artsy's Technology Stack, 2017
 date: 2017-04-14
 categories: [Technology, eigen, force, gravity]
-author: [orta, artsy_engineering]
+author: [orta, artsy-engineering]
 series: Artsy Tech Stack
 ---
 

--- a/_posts/2022-01-06-a-year-in-review-2021.markdown
+++ b/_posts/2022-01-06-a-year-in-review-2021.markdown
@@ -3,7 +3,7 @@ layout: epic
 title: "A Year in Review: 2021"
 date: 2022-01-06
 categories: [team, engineering]
-author: artsy-engineering
+author: [devon, artsy-engineering]
 comment_id: 714
 ---
 

--- a/_posts/2022-01-06-a-year-in-review-2021.markdown
+++ b/_posts/2022-01-06-a-year-in-review-2021.markdown
@@ -3,7 +3,7 @@ layout: epic
 title: "A Year in Review: 2021"
 date: 2022-01-06
 categories: [team, engineering]
-author: artsy_engineering
+author: artsy-engineering
 comment_id: 714
 ---
 


### PR DESCRIPTION
The Artsy Engineering author link 404s because the link points to `/author/artsy_engineering` and the author page is generated with a slug of `/author/artsy-engineering`. This takes the seemingly easier approach of updating the author key in the `_config` file rather than changing how links or pages are generated.