### PR TITLE
Fix search indexing of new category pages

### DIFF
--- a/_plugins/categories.rb
+++ b/_plugins/categories.rb
@@ -35,7 +35,7 @@ module Jekyll
       self.data['category'] = category
 
       category_title_prefix = site.config['category_title_prefix'] || 'Category: '
-      self.data['title'] = "#{category_title_prefix}#{category}"
+      self.data['title'] = "#{category_title_prefix}#{category.name}"
     end
   end
 


### PR DESCRIPTION
Tiny follow up to fix search results that include results like:

```
Category: #<struct Jekyll::CategoryPageGenerator::Category name="webpack", count=1, dir="webpack">
```