### PR TITLE
Update 2016-08-15-vscode.markdown

### DIFF
--- a/_posts/2016-08-15-vscode.markdown
+++ b/_posts/2016-08-15-vscode.markdown
@@ -145,17 +145,14 @@ Awesome!
 [switch_header]: https://github.com/artsy/eigen/blob/master/Artsy/App/ARSwitchBoard.h
 [types]: https://marketplace.visualstudio.com/items?itemName=jvitor83.types-autoinstaller
 [redux_store]: http://redux.js.org/docs/api/Store.html
-[swift_params]:
-  https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Functions.html
+[swift_params]: https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Functions.html
 [ruby_params]: https://robots.thoughtbot.com/ruby-2-keyword-arguments
 [churn]: http://blog.cleancoder.com/uncle-bob/2016/07/27/TheChurn.html
 [vs_extensions]: https://code.visualstudio.com/docs/extensions/overview
 [extensions_approach]: https://code.visualstudio.com/docs/extensions/our-approach
-[xpc]:
-  https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html
+[xpc]: https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html
 [danger_code]: https://marketplace.visualstudio.com/items?itemName=Orta.vscode-danger
-[danger_vscode_load]:
-  https://github.com/orta/vscode-danger/blob/a21ccc101b2b1c1be595b10565bca9c88242fb6f/package.json#L18-L20
+[danger_vscode_load]: https://github.com/orta/vscode-danger/blob/a21ccc101b2b1c1be595b10565bca9c88242fb6f/package.json#L18-L20
 [atom_slow]: https://discuss.atom.io/t/why-is-atom-so-slow/11376
 [vscode_debug]: https://code.visualstudio.com/docs/extensions/example-debuggers
 [ruby_debug]: https://github.com/rubyide/vscode-ruby#debugger


### PR DESCRIPTION
Lots of broken links on this blog posts, I think it's likely that the older markdown parser allowed for newlines in the annotation-style references but an upgrade somewhere down the line stopped supporting that. This PR moves them all to be on the same line.