### PR TITLE
fix: layout when related articles section is empty

### DIFF
--- a/css/epic.scss
+++ b/css/epic.scss
@@ -121,6 +121,10 @@ article.post {
 }
 
 aside.related-articles {
+  display: none;
+  &.loaded {
+    display: block;
+  }
   border-top: 1px lightgrey solid;
   padding: 24px;
   h2 {

--- a/javascripts/related-articles.js
+++ b/javascripts/related-articles.js
@@ -51,5 +51,6 @@ function insertIntoDom(relatedArticles) {
       li.appendChild(a)
       ul.appendChild(li)
     })
+    el.classList.add("loaded")
   }
 }


### PR DESCRIPTION
Tiny layout fix when the `related-articles` aside is empty. 

(Necessary, since not all posts will have related posts)

Before and after…

<img width="500" alt="fix" src="https://github.com/artsy/artsy.github.io/assets/140521/fcbeb1b0-3fa3-48cd-acda-850e919a4765">
