### PR TITLE
feat: update to sans-serif fonts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,12 @@
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   <meta name="author" content="{{ site.author }}">
 
+  <link
+    rel="stylesheet"
+    type="text/css"
+    href="https://webfonts.artsy.net/all-webfonts.css"
+  />
+
   {% capture description %}{% if page.description %}{{ page.description }}{% else %}{{ content | raw_content }}{% endif %}{% endcapture %}
   <meta name="description" content="{{ description | strip_html | condense_spaces | truncate:150 }}">
   {% if page.keywords %}<meta name="keywords" content="{{ page.keywords }}">{% endif %}
@@ -40,11 +46,6 @@
   <script src="{{ root_url }}/javascripts/jquery.scrollTo.min.js"></script>
   {% endif %}
 
-  <script type="text/javascript" src="https://fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js"></script>
-
-
   <link href="{{ root_url }}{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
   {% include google_analytics.html %}
-  <!--[if IE 8]><link href="{{ root_url }}/stylesheets/custom/ie_font.css" type="text/css"><![endif]-->
-
 </head>

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -29,7 +29,6 @@ body > header h2 {
 body {
   line-height: 1.5em;
   color: $text-color;
-  @extend .serif;
 }
 h1 {
   font-size: 2.2em;

--- a/_sass/custom/_fonts.scss
+++ b/_sass/custom/_fonts.scss
@@ -2,11 +2,4 @@
 // To give it a try, uncomment some of the lines below rebuild your blog, and see how it works. your sites's.
 // If you love to use Web Fonts, you also need to add some lines to source/_includes/custom/head.html
 
-//$sans: "Optima", sans-serif;
-// $serif: "AdobeGaramondProRegular",Georgia,Serif;
-$serif: "Adobe Garamond W08", 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-//$mono: "Courier", monospace;
-//$heading-font-family: "Verdana", sans-serif;
-//$header-title-font-family: "Futura", sans-serif;
-//$header-subtitle-font-family: "Futura", sans-serif;
-$block: "ITCAvantGardeGothicStdDemi";
+$sans: "ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif, sans-serif;

--- a/_sass/partials/_blog.scss
+++ b/_sass/partials/_blog.scss
@@ -102,7 +102,6 @@ article + article {
     margin-right: .5em;
     text-decoration: none;
     color: mix($text-color, $text-color-light);
-    @extend .serif;
     @include transition(background-color .5s);
     &:hover {
       background: $link-color-hover;

--- a/artsy-x-react-native.html
+++ b/artsy-x-react-native.html
@@ -3,8 +3,11 @@
 <head>
   <title>Artsy x React Native</title>
   <meta name="viewport" content="width=550px, initial-scale=1.0, maximum-scale=1.0">
-  <link type="text/css" rel="stylesheet" href="https://webfonts.artsy.net/force-webfonts.css?a=b">
-   <!-- <link type=“text/css” rel=“stylesheet” href=“https://webfonts.artsy.net/unica-webfonts.css”> -->
+  <link
+    rel="stylesheet"
+    type="text/css"
+    href="https://webfonts.artsy.net/all-webfonts.css"
+  />
 </head>
 <style>
   html {

--- a/css/epic.scss
+++ b/css/epic.scss
@@ -27,24 +27,25 @@ body > div > div > section > header#page {
 
   // Title
   h1 {
-    font-size: 64px;
-    font-weight: 400;
+    font-size: 60px;
+    line-height: 70px;
+    font-weight: normal;
   }
   // Author subheading
   h3 {
-    font-size: 22px;
-    font-weight: 400;
+    font-size: 20px;
+    font-weight: normal;
   }
   time {
-    font-size: 22px;
-    font-weight: 400;
+    font-size: 20px;
     padding-top: 5px;
+    font-weight: normal;
   }
 }
 
 article.post {
-  font-size: 22px;
-  line-height: 36px;
+  font-size: 20px;
+  line-height: 32px;
   max-width: 740px;
   margin: 0 auto;
   padding-left: 20px;

--- a/css/screen.scss
+++ b/css/screen.scss
@@ -53,7 +53,7 @@ $text-color: #636;
 body {
   background-color: $artsy_bg;
   color: $artsy_text;
-  font-family: $serif;
+  font-family: $sans;
   -webkit-font-smoothing: antialiased;
   -moz-font-smoothing: antialiased;
 
@@ -75,7 +75,7 @@ body {
 
 h1, h2, h3 {
   font-size: 20px;
-  font-weight: 600;
+  font-weight: bold;
   margin: 0;
   margin: 0;
   a {
@@ -270,7 +270,7 @@ header#banner {
         border: none;
         width: 100%;
         margin: 0;
-        font-family: $serif;
+        font-family: $sans;
         color: black;
         font-size: 20px;
         outline: 1px black;


### PR DESCRIPTION
We recently canceled the subscription that was supplying our Garamond fonts, leading to the blog having Times New Roman and a little "view all fonts" thingy in the corner:

<img width="1392" alt="Screenshot 2023-10-06 at 18 32 09" src="https://github.com/artsy/artsy.github.io/assets/5361806/c57fe898-f201-40c9-a6eb-ac42cb1c8a6c">

Took the opportunity to move to our preferred fonts and do light resizing to bring them in line with Palette:
<img width="1392" alt="Screenshot 2023-10-06 at 18 32 25" src="https://github.com/artsy/artsy.github.io/assets/5361806/99296f36-c850-42c4-bf46-d5a2b31255cd">

Definitely lots more cleanup that could be done here, but seemed like a reasonable start.